### PR TITLE
feat: remap teleop controls and add flywheel always-on

### DIFF
--- a/TeamCode/src/main/java/sigmacorns/Robot.kt
+++ b/TeamCode/src/main/java/sigmacorns/Robot.kt
@@ -43,7 +43,8 @@ class Robot(val io: SigmaIO, blue: Boolean, useNativeAim: Boolean = false): Auto
     val ltv = LTVClient(
         drivetrainParameters,
         aTipX = max(antiWheelieFilter.axLimitBwd, antiWheelieFilter.axLimitFwd),
-        aTipY = max(antiWheelieFilter.ayLimitLeft, antiWheelieFilter.ayLimitRight)
+        aTipY = max(antiWheelieFilter.ayLimitLeft, antiWheelieFilter.ayLimitRight),
+        aTipTau = 0.2
     )
 
     val dispatcher = PollableDispatcher(io)

--- a/TeamCode/src/main/java/sigmacorns/Robot.kt
+++ b/TeamCode/src/main/java/sigmacorns/Robot.kt
@@ -28,7 +28,7 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
-class Robot(val io: SigmaIO, blue: Boolean, useNativeAim: Boolean = false): AutoCloseable {
+class Robot(val io: SigmaIO, val blue: Boolean, useNativeAim: Boolean = false): AutoCloseable {
     // Subsystems
     val shooter = Shooter(this)
     val drive = Drivetrain()

--- a/TeamCode/src/main/java/sigmacorns/constants/FieldLandmarks.kt
+++ b/TeamCode/src/main/java/sigmacorns/constants/FieldLandmarks.kt
@@ -57,6 +57,8 @@ object FieldLandmarks {
     val goalZoneCorners = listOf(Vector2d(0.0, 0.0), Vector2d(-1.83, 1.83), Vector2d(1.83, 1.83))
     val farZoneCorners = listOf(Vector2d(-0.61, -1.83), Vector2d(0.0, -1.22), Vector2d(0.61, -1.83))
 
+    val fieldHalfExtend = 1.8288
+
     private val spikeMarkX = 1.200944
     private val spikeMarkFarY = -0.896144
     private val spikeMarkMedY = -0.296069

--- a/TeamCode/src/main/java/sigmacorns/constants/FieldLandmarks.kt
+++ b/TeamCode/src/main/java/sigmacorns/constants/FieldLandmarks.kt
@@ -4,6 +4,7 @@ import org.joml.Quaterniond
 import org.joml.Vector2d
 import org.joml.Vector3d
 import sigmacorns.control.localization.GTSAMEstimator
+import sigmacorns.math.Pose2d
 import kotlin.math.PI
 
 /**
@@ -56,6 +57,14 @@ object FieldLandmarks {
 
     val goalZoneCorners = listOf(Vector2d(0.0, 0.0), Vector2d(-1.83, 1.83), Vector2d(1.83, 1.83))
     val farZoneCorners = listOf(Vector2d(-0.61, -1.83), Vector2d(0.0, -1.22), Vector2d(0.61, -1.83))
+
+    fun gateIntakePosition(blue: Boolean): Pose2d {
+        return Pose2d(
+            (if(blue) 1.0 else -1.0) * 1.467,
+            -0.146,
+            if(blue) PI - PI/3.0 else PI/3.0
+        )
+    }
 
     val fieldHalfExtend = 1.8288
 

--- a/TeamCode/src/main/java/sigmacorns/constants/RobotModelConstants.kt
+++ b/TeamCode/src/main/java/sigmacorns/constants/RobotModelConstants.kt
@@ -98,7 +98,7 @@ val antiWheelieConfig = AntiWheelieConfig(
     comHeight = 0.1212075,
     comOffsetX = -0.00465600,
     comOffsetY = 0.0,
-    minNormalFraction = 0.05
+    minNormalFraction = -0.05
 )
 
 val antiWheelieFilter = AntiWheelieFilter(MecanumDynamics(drivetrainParameters), antiWheelieConfig)

--- a/TeamCode/src/main/java/sigmacorns/control/aim/ApproachPrepositioner.kt
+++ b/TeamCode/src/main/java/sigmacorns/control/aim/ApproachPrepositioner.kt
@@ -50,7 +50,7 @@ class ApproachPrepositioner(
      * @param curTheta Current turret angle in field frame (rad).
      * @param curPhi Current hood angle (rad).
      * @param curOmega Current flywheel speed (rad/s).
-     * @param omegaDrop Expected flywheel drop between consecutive shots (rad/s).
+     * @param dropFraction Expected flywheel drop between consecutive shots (rad/s).
      * @param horizonSeconds Look-ahead horizon for the predicted trajectory (s).
      * @param steps Number of samples along the horizon (>= 2).
      * @param lambdaDecay Exponential decay on sample weights (0 = uniform).
@@ -67,7 +67,7 @@ class ApproachPrepositioner(
         curTheta: Double,
         curPhi: Double,
         curOmega: Double,
-        omegaDrop: Double,
+        dropFraction: Double,
         horizonSeconds: Double,
         steps: Int,
         lambdaDecay: Double,
@@ -98,7 +98,7 @@ class ApproachPrepositioner(
                 goal.z.toFloat(),
                 curTheta.toFloat(), curPhi.toFloat(), curOmega.toFloat(),
                 tAvailable.toFloat(), lambdaDecay.toFloat(), k,
-                omegaDrop.toFloat(),
+                dropFraction.toFloat(),
                 weights, bounds, physConfig, omegaCoeffs
             )
         } catch (e: Exception) {

--- a/TeamCode/src/main/java/sigmacorns/control/aim/AutoAim.kt
+++ b/TeamCode/src/main/java/sigmacorns/control/aim/AutoAim.kt
@@ -2,6 +2,7 @@ package sigmacorns.control.aim
 
 import org.joml.Vector2d
 import sigmacorns.control.localization.GTSAMEstimator
+import sigmacorns.logic.PlannedShot
 import sigmacorns.math.Pose2d
 import kotlin.time.Duration
 
@@ -68,6 +69,16 @@ interface AutoAim : AutoCloseable {
 
     /** True when the most recent update produced a robust (multi-shot) solve. */
     val isRobustActive: Boolean
+
+    /**
+     * Optional pre-planned shot target from an autonomous routine.
+     * When set, the implementation should prespin and pre-aim for the shot at
+     * [PlannedShot.state] so it fires with minimal delay on arrival.
+     * The default is a no-op (appropriate for implementations that ignore pre-planning).
+     */
+    var plannedShot: PlannedShot?
+        get() = null
+        set(_) {}
 
     /** Called once before the main loop. Initialises GTSAM with the robot's starting pose. */
     fun init(initialPose: Pose2d, apriltagTracking: Boolean)

--- a/TeamCode/src/main/java/sigmacorns/control/aim/AutoAim.kt
+++ b/TeamCode/src/main/java/sigmacorns/control/aim/AutoAim.kt
@@ -69,9 +69,6 @@ interface AutoAim : AutoCloseable {
     /** True when the most recent update produced a robust (multi-shot) solve. */
     val isRobustActive: Boolean
 
-    /** True when the most recent update produced an approach-preposition target. */
-    val isPrepositionActive: Boolean
-
     /** Called once before the main loop. Initialises GTSAM with the robot's starting pose. */
     fun init(initialPose: Pose2d, apriltagTracking: Boolean)
 

--- a/TeamCode/src/main/java/sigmacorns/control/aim/AutoAim.kt
+++ b/TeamCode/src/main/java/sigmacorns/control/aim/AutoAim.kt
@@ -60,7 +60,13 @@ interface AutoAim : AutoCloseable {
      */
     val secondaryShotState: Ballistics.ShotState?
 
-    /** True when the most recent update produced a robust (two-shot) solve. */
+    /**
+     * Third leg of the most recent 3-shot robust solve. Non-null only when
+     * [isRobustActive] and the planner solved for 3 balls.
+     */
+    val tertiaryShotState: Ballistics.ShotState?
+
+    /** True when the most recent update produced a robust (multi-shot) solve. */
     val isRobustActive: Boolean
 
     /** True when the most recent update produced an approach-preposition target. */

--- a/TeamCode/src/main/java/sigmacorns/control/aim/TurretPlannerBridge.kt
+++ b/TeamCode/src/main/java/sigmacorns/control/aim/TurretPlannerBridge.kt
@@ -79,28 +79,30 @@ class TurretPlannerBridge {
         const val S2_OMEGA  = 11
     }
 
-    /** Index constants for the 20-element array from [robust3ShotPlan]. */
+    /** Index constants for the 22-element array from [robust3ShotPlan]. */
     object Robust3ShotPlanIdx {
         const val FEASIBLE  = 0
         const val IDX1      = 1
         const val IDX2      = 2
         const val IDX3      = 3
         const val J         = 4
-        const val T1        = 5
-        const val T2        = 6
-        const val T3        = 7
-        const val S1_THETA  = 8
-        const val S1_PHI    = 9
-        const val S1_V_EXIT = 10
-        const val S1_OMEGA  = 11
-        const val S2_THETA  = 12
-        const val S2_PHI    = 13
-        const val S2_V_EXIT = 14
-        const val S2_OMEGA  = 15
-        const val S3_THETA  = 16
-        const val S3_PHI    = 17
-        const val S3_V_EXIT = 18
-        const val S3_OMEGA  = 19
+        const val J_12      = 5
+        const val J_23      = 6
+        const val T1        = 7
+        const val T2        = 8
+        const val T3        = 9
+        const val S1_THETA  = 10
+        const val S1_PHI    = 11
+        const val S1_V_EXIT = 12
+        const val S1_OMEGA  = 13
+        const val S2_THETA  = 14
+        const val S2_PHI    = 15
+        const val S2_V_EXIT = 16
+        const val S2_OMEGA  = 17
+        const val S3_THETA  = 18
+        const val S3_PHI    = 19
+        const val S3_V_EXIT = 20
+        const val S3_OMEGA  = 21
     }
 
     /** Index constants for the 8-element array from [updateZoneTracker]. */
@@ -131,6 +133,19 @@ class TurretPlannerBridge {
         physConfig: FloatArray,
         omegaCoeffs: FloatArray
     ): FloatArray
+
+    /**
+     * Forward-simulate a shot and return the horizontal miss distance (m)
+     * at the target height. Accounts for air drag.
+     */
+    external fun shotError(
+        turretX: Float, turretY: Float, turretZ: Float,
+        targetX: Float, targetY: Float, targetZ: Float,
+        robotVx: Float, robotVy: Float,
+        theta: Float, phi: Float, vExit: Float, omega: Float,
+        T: Float,
+        physConfig: FloatArray
+    ): Float
 
     // ------------------------------------------------------------------
     // Flight time optimizers
@@ -240,11 +255,12 @@ class TurretPlannerBridge {
      * timing candidates and jointly optimizes flight times (T1, T2, T3) via
      * branch-and-bound to minimize transition costs between consecutive shots.
      *
-     * The first shot cannot happen before [tRemaining] + [transferTime].
-     * [urgencyLambda] controls how much the slew cost to shot 1 matters:
-     * w = exp(-lambda * tRemaining). Large tRemaining -> turret has time to prepare.
+     * The first shot cannot happen before [tRemaining] on the trajectory.
      *
-     * @return FloatArray(20): see [Robust3ShotPlanIdx]
+     * Minimizes J_0 + J_12 + J_23 subject to J_12 <= transferTime and
+     * J_23 <= transferTime (transitions must complete within the transfer window).
+     *
+     * @return FloatArray(22): see [Robust3ShotPlanIdx]
      */
     external fun robust3ShotPlan(
         trajectory: FloatArray, nStates: Int,
@@ -255,7 +271,6 @@ class TurretPlannerBridge {
         tRemaining: Float,
         transferTime: Float,
         dropFraction: Float,
-        urgencyLambda: Float,
         weights: FloatArray,
         bounds: FloatArray,
         physConfig: FloatArray,

--- a/TeamCode/src/main/java/sigmacorns/control/aim/TurretPlannerBridge.kt
+++ b/TeamCode/src/main/java/sigmacorns/control/aim/TurretPlannerBridge.kt
@@ -7,7 +7,7 @@ import sigmacorns.opmode.SigmaOpMode.Companion.SIM
  * JNI bridge to the native turret_planner library (libturret_planner_jni.so).
  *
  * Config array layouts (must match turret_planner_jni.cpp):
- *   physConfig  [2]:  g (m/s²), rH (barrel offset, m)
+ *   physConfig  [3]:  g (m/s²), rH (barrel offset, m), dragK (1/s, 0=no drag)
  *   bounds      [6]:  thetaMin, thetaMax, phiMin, phiMax, vExitMax, omegaMax
  *   weights     [3]:  wTheta (s/rad), wPhi (s/rad), wOmega (s/unit)
  *   omegaCoeffs [6]:  c0..c5 for ω(φ,v) = c0 + c1·v + c2·φ + c3·v² + c4·φv + c5·φ²
@@ -79,6 +79,30 @@ class TurretPlannerBridge {
         const val S2_OMEGA  = 11
     }
 
+    /** Index constants for the 20-element array from [robust3ShotPlan]. */
+    object Robust3ShotPlanIdx {
+        const val FEASIBLE  = 0
+        const val IDX1      = 1
+        const val IDX2      = 2
+        const val IDX3      = 3
+        const val J         = 4
+        const val T1        = 5
+        const val T2        = 6
+        const val T3        = 7
+        const val S1_THETA  = 8
+        const val S1_PHI    = 9
+        const val S1_V_EXIT = 10
+        const val S1_OMEGA  = 11
+        const val S2_THETA  = 12
+        const val S2_PHI    = 13
+        const val S2_V_EXIT = 14
+        const val S2_OMEGA  = 15
+        const val S3_THETA  = 16
+        const val S3_PHI    = 17
+        const val S3_V_EXIT = 18
+        const val S3_OMEGA  = 19
+    }
+
     /** Index constants for the 8-element array from [updateZoneTracker]. */
     object ZoneTrackerIdx {
         const val URGENCY          = 0
@@ -148,11 +172,11 @@ class TurretPlannerBridge {
 
     /**
      * Plan a pair of consecutive shots (target1 then target2) that are robust
-     * to an expected flywheel speed drop [omegaDrop] between them.
+     * to an expected flywheel speed drop [dropFraction] between them.
      *
      * Minimizes `J(T1, T2) = max(w_theta·|Δθ|, w_phi·|Δφ|, w_omega·|Δω_adj|)`
-     * where Δω_adj accounts for subtracting [omegaDrop] from shot 1's required
-     * flywheel speed (modeling energy loss after firing).
+     * where Δω_adj accounts for scaling shot 1's required flywheel speed by
+     * (1 - [dropFraction]) to model the proportional energy loss after firing.
      *
      * @return FloatArray(12): [feasible, T1, T2, J,
      *                          s1.theta, s1.phi, s1.vExit, s1.omega,
@@ -163,7 +187,7 @@ class TurretPlannerBridge {
         target1X: Float, target1Y: Float, target1Z: Float,
         target2X: Float, target2Y: Float, target2Z: Float,
         robotVx: Float, robotVy: Float,
-        omegaDrop: Float,
+        dropFraction: Float,
         weights: FloatArray,
         bounds: FloatArray,
         physConfig: FloatArray,
@@ -180,7 +204,7 @@ class TurretPlannerBridge {
      *
      * The first term is the slew cost from the current turret state to the
      * first shot; the second is the cost of transitioning from shot 1 (with
-     * its flywheel speed reduced by [omegaDrop]) to shot 2. Same return shape
+     * its flywheel speed scaled by (1-[dropFraction])) to shot 2. Same return shape
      * as [robustShot] — see [RobustShotIdx].
      *
      * Use when the robot is already inside a shooting zone and you want the
@@ -194,13 +218,50 @@ class TurretPlannerBridge {
         target2X: Float, target2Y: Float, target2Z: Float,
         robotVx: Float, robotVy: Float,
         curTheta: Float, curPhi: Float, curOmega: Float,
-        omegaDrop: Float,
+        dropFraction: Float,
         weights: FloatArray,
         bounds: FloatArray,
         physConfig: FloatArray,
         omegaCoeffs: FloatArray,
         tol: Float = 5e-4f,
         maxIter: Int = 40
+    ): FloatArray
+
+    // ------------------------------------------------------------------
+    // Trajectory-aware N-shot planner
+    // ------------------------------------------------------------------
+
+    /**
+     * Plan up to 3 consecutive shots along a predicted trajectory.
+     *
+     * [trajectory] is a flat FloatArray with 6 floats per state: [t, x, y, heading, vx, vy].
+     * Shot timing is deterministic: shot 2 fires at shot1_time + [transferTime],
+     * shot 3 at shot1_time + 2*[transferTime]. The solver sweeps over first-shot
+     * timing candidates and jointly optimizes flight times (T1, T2, T3) via
+     * branch-and-bound to minimize transition costs between consecutive shots.
+     *
+     * The first shot cannot happen before [tRemaining] + [transferTime].
+     * [urgencyLambda] controls how much the slew cost to shot 1 matters:
+     * w = exp(-lambda * tRemaining). Large tRemaining -> turret has time to prepare.
+     *
+     * @return FloatArray(20): see [Robust3ShotPlanIdx]
+     */
+    external fun robust3ShotPlan(
+        trajectory: FloatArray, nStates: Int,
+        turretZ: Float,
+        targetX: Float, targetY: Float, targetZ: Float,
+        curTheta: Float, curPhi: Float, curOmega: Float,
+        nBalls: Int,
+        tRemaining: Float,
+        transferTime: Float,
+        dropFraction: Float,
+        urgencyLambda: Float,
+        weights: FloatArray,
+        bounds: FloatArray,
+        physConfig: FloatArray,
+        omegaCoeffs: FloatArray,
+        tol: Float = 5e-4f,
+        maxIter: Int = 80
     ): FloatArray
 
     // ------------------------------------------------------------------
@@ -259,10 +320,10 @@ class TurretPlannerBridge {
      * solved as the first half of a robust pair against the next sample
      * (see [robustShot]), biasing the pre-position toward turret states that
      * make the *following* shot easy under an expected flywheel drop
-     * [omegaDrop].
+     * [dropFraction].
      *
      * Note: this is NOT equivalent to [computePreposition] even when
-     * `omegaDrop == 0`, because the two functions optimize different objectives
+     * `dropFraction == 0`, because the two functions optimize different objectives
      * per sample — [computePreposition] minimizes τ from the current turret
      * state to the shot, while this minimizes the transition between
      * consecutive shots.
@@ -278,7 +339,7 @@ class TurretPlannerBridge {
         tAvailable: Float,
         lambdaDecay: Float,
         kSamples: Int,
-        omegaDrop: Float,
+        dropFraction: Float,
         weights: FloatArray,
         bounds: FloatArray,
         physConfig: FloatArray,
@@ -343,6 +404,20 @@ class TurretPlannerBridge {
             }
         }
 
+        /** Encode a trajectory for [robust3ShotPlan]. 6 floats per state: [t, x, y, heading, vx, vy]. */
+        fun encodeTrajectory(states: List<TrajectoryState>): FloatArray {
+            val out = FloatArray(states.size * 6)
+            states.forEachIndexed { i, s ->
+                out[i*6 + 0] = s.t
+                out[i*6 + 1] = s.x
+                out[i*6 + 2] = s.y
+                out[i*6 + 3] = s.heading
+                out[i*6 + 4] = s.vx
+                out[i*6 + 5] = s.vy
+            }
+            return out
+        }
+
         /** Encode a path for [findEarliestShot] / [computePreposition]. */
         fun encodePath(samples: List<PathSample>): FloatArray {
             val out = FloatArray(samples.size * 5)
@@ -365,4 +440,14 @@ data class PathSample(
     val y: Float,
     val vx: Float = 0f,
     val vy: Float = 0f
+)
+
+/** Predicted robot state at a future time, for [TurretPlannerBridge.robust3ShotPlan]. */
+data class TrajectoryState(
+    val t: Float,          // seconds from now
+    val x: Float,          // predicted field-frame position (m)
+    val y: Float,
+    val heading: Float,    // predicted heading (rad)
+    val vx: Float,         // predicted field-frame velocity (m/s)
+    val vy: Float
 )

--- a/TeamCode/src/main/java/sigmacorns/control/aim/TurretPlannerBridge.kt
+++ b/TeamCode/src/main/java/sigmacorns/control/aim/TurretPlannerBridge.kt
@@ -414,7 +414,7 @@ class TurretPlannerBridge {
                 if (resolvedPath != null) {
                     System.load(resolvedPath)
                 } else {
-                    System.loadLibrary("mecanum_ltv_jni")
+                    System.loadLibrary("turret_planner_jni")
                 }
             }
         }

--- a/TeamCode/src/main/java/sigmacorns/control/ltv/LTVClient.kt
+++ b/TeamCode/src/main/java/sigmacorns/control/ltv/LTVClient.kt
@@ -45,6 +45,9 @@ class LTVClient private constructor(
     private val handle: Long,
     private var dtSeconds: Double,
     private var solverType: QpSolverType = QpSolverType.NEON_IPM,
+    val qDiag: DoubleArray,
+    val qfDiag: DoubleArray,
+    val rDiag: DoubleArray
 ) : AutoCloseable {
 
     private var numWindows: Int = 0
@@ -56,6 +59,7 @@ class LTVClient private constructor(
 
     val dt: Duration get() = dtSeconds.seconds
 
+
     /**
      * Primary constructor: configure model params + MPC tuning, then call [loadTrajectory].
      */
@@ -63,9 +67,9 @@ class LTVClient private constructor(
         parameters: MecanumParameters,
         horizon: Int = 30,
         dt: Duration = 20.milliseconds,
-        qDiag: DoubleArray = doubleArrayOf(100.0, 100.0, 100.0, 1.0, 1.0, 1.0),
-        rDiag: DoubleArray = doubleArrayOf(0.03, 0.03, 0.03, 0.03),
-        qfDiag: DoubleArray = doubleArrayOf(100.0, 100.0, 100.0, 2.0, 2.0, 2.0),
+        qDiag: DoubleArray = doubleArrayOf(100.0, 100.0, 400.0, 1.0, 1.0, 1.0),
+        rDiag: DoubleArray = doubleArrayOf(0.05, 0.05, 0.05, 0.05),
+        qfDiag: DoubleArray = doubleArrayOf(100.0, 100.0, 400.0, 2.0, 2.0, 2.0),
         solverType: QpSolverType = QpSolverType.NEON_IPM,
         windowSelConfig: WindowSelConfig = WindowSelConfig(),
         /** Anti-tip X acceleration limit (m/s²) in robot body frame. 0 = disabled.
@@ -74,7 +78,7 @@ class LTVClient private constructor(
         /** Anti-tip Y acceleration limit (m/s²) in robot body frame. 0 = disabled.
          *  Typical value: g * (half lateral track width) / h_com */
         aTipY: Double = 0.0,
-    ) : this(MecanumLTVBridge.nativeCreate(), dt.toDouble(DurationUnit.SECONDS)) {
+    ) : this(MecanumLTVBridge.nativeCreate(), dt.toDouble(DurationUnit.SECONDS),qDiag=qDiag, qfDiag=qfDiag, rDiag=rDiag) {
         MecanumLTVBridge.nativeSetModelParams(
             handle,
             mass = parameters.weight,
@@ -197,7 +201,6 @@ class LTVClient private constructor(
         target: MecanumState,
         tRemaining: Duration,
         lqrRef: Boolean = false,
-        qDiag: DoubleArray = doubleArrayOf(100.0, 100.0, 20.0, 1.0, 1.0, 1.0),
         r: Double = 0.020,
     ): DoubleArray {
         val x0 = doubleArrayOf(
@@ -221,16 +224,12 @@ class LTVClient private constructor(
     fun holdPos(
         io: SigmaIO,
         p: Pose2d,
-        qDiag: DoubleArray = doubleArrayOf(100.0, 100.0, 100.0, 1.0, 1.0, 1.0),
-        r: Double = 0.015,
     ) {
         val u = solveWaypoint(
             MecanumState(io.velocity(),io.position()),
             MecanumState(Pose2d(),p),
             1.seconds,
-            lqrRef = true,
-            qDiag,
-            r
+            lqrRef = true
         )
 
         val voltage = io.voltage()

--- a/TeamCode/src/main/java/sigmacorns/control/ltv/LTVClient.kt
+++ b/TeamCode/src/main/java/sigmacorns/control/ltv/LTVClient.kt
@@ -78,6 +78,12 @@ class LTVClient private constructor(
         /** Anti-tip Y acceleration limit (m/s²) in robot body frame. 0 = disabled.
          *  Typical value: g * (half lateral track width) / h_com */
         aTipY: Double = 0.0,
+        /** Low-pass time constant (s) for the sustained-acceleration tip constraint.
+         *  0 (default) → per-step instantaneous barrier (original).
+         *  Values ~half the robot's pitch period (e.g. 0.15–0.4 s) allow brief
+         *  transient accelerations while preventing sustained tip-inducing deceleration,
+         *  eliminating mid-path chattering without sacrificing end-of-path protection. */
+        aTipTau: Double = 0.0,
     ) : this(MecanumLTVBridge.nativeCreate(), dt.toDouble(DurationUnit.SECONDS),qDiag=qDiag, qfDiag=qfDiag, rDiag=rDiag) {
         MecanumLTVBridge.nativeSetModelParams(
             handle,
@@ -91,7 +97,7 @@ class LTVClient private constructor(
             stallTorque = parameters.motor.stallTorque,
             freeSpeed = parameters.motor.freeSpeed,
         )
-        MecanumLTVBridge.nativeSetConfig(handle, horizon, qDiag, rDiag, qfDiag, -1.0, 1.0, aTipX, aTipY)
+        MecanumLTVBridge.nativeSetConfig(handle, horizon, qDiag, rDiag, qfDiag, -1.0, 1.0, aTipX, aTipY, aTipTau)
         this.solverType = solverType
         MecanumLTVBridge.nativeSetSolverType(handle, solverType.nativeId)
         setWindowSelConfig(windowSelConfig)

--- a/TeamCode/src/main/java/sigmacorns/control/ltv/LTVClient.kt
+++ b/TeamCode/src/main/java/sigmacorns/control/ltv/LTVClient.kt
@@ -350,14 +350,15 @@ class LTVClient private constructor(
             io.driveBR = u[2] * 12.0 / voltage
             io.driveFR = u[3] * 12.0 / voltage
 
-            // Update tRemaining from solver's forward-simulated ETA
-            tRemaining = prevWaypointEta().coerceAtLeast(minTRemaining)
-
-            // Check arrival: XY position, heading, and velocity magnitude
+            // Update tRemaining from solver's forward-simulated ETA,
+            // but floor it with a distance-based estimate so a single bad
+            // native ETA can't collapse the horizon to 2 steps permanently.
             val posErr = hypot(
                 currentState.pos.v.x - target.pos.v.x,
                 currentState.pos.v.y - target.pos.v.y,
             )
+            val distBasedMin = (posErr / 1.5).seconds // 1.5 m/s reference speed
+            tRemaining = maxOf(prevWaypointEta(), distBasedMin, minTRemaining)
             val headingErr = abs(currentState.pos.rot - target.pos.rot)
             val velMag = hypot(currentState.vel.v.x, currentState.vel.v.y)
 

--- a/TeamCode/src/main/java/sigmacorns/control/ltv/MecanumLTVBridge.kt
+++ b/TeamCode/src/main/java/sigmacorns/control/ltv/MecanumLTVBridge.kt
@@ -31,7 +31,7 @@ object MecanumLTVBridge {
         N: Int,
         qDiag: DoubleArray, rDiag: DoubleArray, qfDiag: DoubleArray,
         uMin: Double, uMax: Double,
-        aTipX: Double, aTipY: Double,
+        aTipX: Double, aTipY: Double, aTipTau: Double,
     )
 
     /** Load trajectory as flat array of [t, px, py, theta, vx, vy, omega] per sample. Returns number of windows. */

--- a/TeamCode/src/main/java/sigmacorns/io/JoltSimIO.kt
+++ b/TeamCode/src/main/java/sigmacorns/io/JoltSimIO.kt
@@ -351,7 +351,7 @@ class JoltSimIO(
 
         // Flywheel inertia: ½mr² = 0.5 * 0.38709252 kg * (0.046 m)²
         const val SIM_FLYWHEEL_INERTIA = 0.000410 // kg·m^2
-        val SIM_FLYWHEEL_PARAMS = FlywheelParameters(flywheelMotor, SIM_FLYWHEEL_INERTIA, 0.0001)
+        val SIM_FLYWHEEL_PARAMS = FlywheelParameters(flywheelMotor, SIM_FLYWHEEL_INERTIA, 0.0)
 
         // Intake roller dynamics (reuses FlywheelDynamics with different parameters)
         const val INTAKE_ROLLER_INERTIA = 0.0005 // kg·m^2

--- a/TeamCode/src/main/java/sigmacorns/io/JoltSimIO.kt
+++ b/TeamCode/src/main/java/sigmacorns/io/JoltSimIO.kt
@@ -244,7 +244,7 @@ class JoltSimIO(
             color.joltId)
 
         // slow down flywheel
-        flywheelState.omega *= 0.8
+        flywheelState.omega *= (1.0-FLYWHEEL_SHOT_LOSS)
     }
 
     // --- Intake/Hood getters ---
@@ -343,8 +343,9 @@ class JoltSimIO(
         val SIM_UPDATE_TIME = 5.milliseconds
 
         /** Time between auto-shot attempts when transfer motor is running (seconds). */
-        const val AUTO_SHOOT_INTERVAL = 0.3
-        const val LAUNCH_EFFICIENCY = 0.27
+        const val AUTO_SHOOT_INTERVAL = 0.2
+        const val LAUNCH_EFFICIENCY = 0.195
+        const val FLYWHEEL_SHOT_LOSS = 0.1
 
         const val SERVO_TIME_CONSTANT = 0.05
 

--- a/TeamCode/src/main/java/sigmacorns/logic/AimingSystem.kt
+++ b/TeamCode/src/main/java/sigmacorns/logic/AimingSystem.kt
@@ -79,7 +79,6 @@ class AimingSystem(
     override val secondaryShotState: Ballistics.ShotState? get() = null
     override val tertiaryShotState: Ballistics.ShotState? get() = null
     override val isRobustActive: Boolean get() = false
-    override val isPrepositionActive: Boolean get() = false
 
     /**
      * Initialize all subsystems. Call once before the main loop.
@@ -275,10 +274,10 @@ object AimConfig {
     @JvmField var g = 9.81
 
     /** Linear air drag coefficient (1/s). 0 = no drag. Tune empirically (~0.3-0.8 for wiffle balls). */
-    @JvmField var dragK = 0.5
+    @JvmField var dragK = 0.3
 
     /** Time (seconds) from when shot is requested until ball leaves shooter */
-    @JvmField var transferDelay = 0.15
+    @JvmField var transferDelay = 0.2
 
     @JvmField var launchEfficiency = 0.195
     val omegaMap = object : OmegaMap {
@@ -296,46 +295,33 @@ object AimConfig {
     @JvmField var vMax = flywheelMotor.freeSpeed * launchEfficiency * flywheelRadius
 
     // shots area allowed when the ball will pass < shotTolerance distance from the target when the ball is at the same height as the target
-    @JvmField var shotTolerance = 0.03 // m
+    @JvmField var shotTolerance = 0.07 // m
 
     // Proportional flywheel speed loss per shot. After firing, the flywheel
     // retains (1 - dropFraction) of its speed. When > 0, NativeAutoAim uses
     // the robust shot planner so the first shot's parameters leave the flywheel
     // at a speed compatible with the next shot after this proportional loss.
     // Set to 0 to fall back to single-shot optimal aim.
-    @JvmField var dropFraction = 0.2
+    @JvmField var dropFraction = 0.1
 
     // Trajectory prediction for the robust 3-shot planner.
     @JvmField var predictionHorizon = 1.0   // seconds of trajectory to predict
     @JvmField var predictionStep = 0.04     // seconds between trajectory samples
-    @JvmField var urgencyLambda = 1.0       // J_0 weight decay: w = exp(-lambda * t_remaining)
 
-    // Approach prepositioning: when > 0, NativeAutoAim predicts the robot's
-    // near-future trajectory via constant-velocity mecanum kinematics and
-    // uses computeRobustPreposition() while the robot is outside a shooting
-    // zone (see launchZone* below), with tAvailable set to the predicted
-    // half-plane crossing time.
-    @JvmField var prepositionHorizon    = 1.2   // seconds; 0 = disabled
-    @JvmField var prepositionSteps      = 6
-    @JvmField var prepositionLambda     = 0.5   // weight decay e^(-lambda*i)
-    @JvmField var prepositionTAvailable = 1.0   // fallback slew time (s) when not approaching
+    /** Flywheel spins up when estimated time to a launch zone is below this (seconds). */
+    @JvmField var spinupLeadTime = 2.2
 
-    // Launch zone half-plane `nx·x + ny·y >= d` (field frame).
-    //
-    // When (launchZoneNx, launchZoneNy) is non-zero the shooting logic splits:
-    //   - outside the zone: robust preposition with tAvailable = time until entry
-    //   - inside the zone : robustAdjust — minimize total time to fire two balls
-    // When the normal is the zero vector the feature is inert and NativeAutoAim
-    // falls back to its single-shot / robustShot behavior regardless of pose.
-    @JvmField var launchZoneNx = 0.0
-    @JvmField var launchZoneNy = 0.0
-    @JvmField var launchZoneD  = 0.0
+    /** Start decelerating trajectory when within this distance of a shooting zone (m). */
+    @JvmField var decelZoneMargin = 0.25
+
+    /** Assumed deceleration rate when approaching a zone (m/s²). */
+    @JvmField var decelRate = 2.0f
 
 }
 
 object ShotSolverConfig {
-    @JvmField var wOmega = 0.02   // s per rad/s flywheel change
+    @JvmField var wOmega = 0.005   // s per rad/s flywheel change
     @JvmField var wTheta = 0.1    // s per rad turret change
-    @JvmField var wPhi = 0.3      // s per rad hood change
+    @JvmField var wPhi = 0.07      // s per rad hood change
     @JvmField var tolerance = 0.05
 }

--- a/TeamCode/src/main/java/sigmacorns/logic/AimingSystem.kt
+++ b/TeamCode/src/main/java/sigmacorns/logic/AimingSystem.kt
@@ -77,6 +77,7 @@ class AimingSystem(
     override var primaryShotState: Ballistics.ShotState? = null
         private set
     override val secondaryShotState: Ballistics.ShotState? get() = null
+    override val tertiaryShotState: Ballistics.ShotState? get() = null
     override val isRobustActive: Boolean get() = false
     override val isPrepositionActive: Boolean get() = false
 
@@ -273,8 +274,11 @@ object AimConfig {
     @JvmField var goalHeight = 1.14
     @JvmField var g = 9.81
 
+    /** Linear air drag coefficient (1/s). 0 = no drag. Tune empirically (~0.3-0.8 for wiffle balls). */
+    @JvmField var dragK = 0.5
+
     /** Time (seconds) from when shot is requested until ball leaves shooter */
-    @JvmField var transferDelay = 0.2
+    @JvmField var transferDelay = 0.15
 
     @JvmField var launchEfficiency = 0.195
     val omegaMap = object : OmegaMap {
@@ -292,13 +296,19 @@ object AimConfig {
     @JvmField var vMax = flywheelMotor.freeSpeed * launchEfficiency * flywheelRadius
 
     // shots area allowed when the ball will pass < shotTolerance distance from the target when the ball is at the same height as the target
-    @JvmField var shotTolerance = 0.05 // m
+    @JvmField var shotTolerance = 0.03 // m
 
-    // Expected flywheel speed drop (rad/s) between consecutive shots. When > 0,
-    // NativeAutoAim uses the robust shot planner so the first shot's parameters
-    // leave the flywheel at a speed compatible with the next shot after losing
-    // this amount. Set to 0 to fall back to single-shot optimal aim.
-    @JvmField var flywheelDrop = 20.0
+    // Proportional flywheel speed loss per shot. After firing, the flywheel
+    // retains (1 - dropFraction) of its speed. When > 0, NativeAutoAim uses
+    // the robust shot planner so the first shot's parameters leave the flywheel
+    // at a speed compatible with the next shot after this proportional loss.
+    // Set to 0 to fall back to single-shot optimal aim.
+    @JvmField var dropFraction = 0.2
+
+    // Trajectory prediction for the robust 3-shot planner.
+    @JvmField var predictionHorizon = 1.0   // seconds of trajectory to predict
+    @JvmField var predictionStep = 0.04     // seconds between trajectory samples
+    @JvmField var urgencyLambda = 1.0       // J_0 weight decay: w = exp(-lambda * t_remaining)
 
     // Approach prepositioning: when > 0, NativeAutoAim predicts the robot's
     // near-future trajectory via constant-velocity mecanum kinematics and
@@ -324,8 +334,8 @@ object AimConfig {
 }
 
 object ShotSolverConfig {
-    @JvmField var wOmega = 0.01   // s per rad/s flywheel change
+    @JvmField var wOmega = 0.02   // s per rad/s flywheel change
     @JvmField var wTheta = 0.1    // s per rad turret change
-    @JvmField var wPhi = 0.05      // s per rad hood change
+    @JvmField var wPhi = 0.3      // s per rad hood change
     @JvmField var tolerance = 0.05
 }

--- a/TeamCode/src/main/java/sigmacorns/logic/AimingSystem.kt
+++ b/TeamCode/src/main/java/sigmacorns/logic/AimingSystem.kt
@@ -274,12 +274,12 @@ object AimConfig {
     @JvmField var g = 9.81
 
     /** Linear air drag coefficient (1/s). 0 = no drag. Tune empirically (~0.3-0.8 for wiffle balls). */
-    @JvmField var dragK = 0.3
+    @JvmField var dragK = 0.4
 
     /** Time (seconds) from when shot is requested until ball leaves shooter */
     @JvmField var transferDelay = 0.2
 
-    @JvmField var launchEfficiency = 0.195
+    @JvmField var launchEfficiency = 0.22
     val omegaMap = object : OmegaMap {
         override fun omega(hood: Double, vExit: Double) =
             vExit / (flywheelRadius * launchEfficiency)
@@ -295,14 +295,14 @@ object AimConfig {
     @JvmField var vMax = flywheelMotor.freeSpeed * launchEfficiency * flywheelRadius
 
     // shots area allowed when the ball will pass < shotTolerance distance from the target when the ball is at the same height as the target
-    @JvmField var shotTolerance = 0.10 // m
+    @JvmField var shotTolerance = 0.15 // m
 
     // Proportional flywheel speed loss per shot. After firing, the flywheel
     // retains (1 - dropFraction) of its speed. When > 0, NativeAutoAim uses
     // the robust shot planner so the first shot's parameters leave the flywheel
     // at a speed compatible with the next shot after this proportional loss.
     // Set to 0 to fall back to single-shot optimal aim.
-    @JvmField var dropFraction = 0.1
+    @JvmField var dropFraction = 0.08
 
     // Trajectory prediction for the robust 3-shot planner.
     @JvmField var predictionHorizon = 1.0   // seconds of trajectory to predict

--- a/TeamCode/src/main/java/sigmacorns/logic/AimingSystem.kt
+++ b/TeamCode/src/main/java/sigmacorns/logic/AimingSystem.kt
@@ -295,7 +295,7 @@ object AimConfig {
     @JvmField var vMax = flywheelMotor.freeSpeed * launchEfficiency * flywheelRadius
 
     // shots area allowed when the ball will pass < shotTolerance distance from the target when the ball is at the same height as the target
-    @JvmField var shotTolerance = 0.07 // m
+    @JvmField var shotTolerance = 0.10 // m
 
     // Proportional flywheel speed loss per shot. After firing, the flywheel
     // retains (1 - dropFraction) of its speed. When > 0, NativeAutoAim uses
@@ -309,7 +309,7 @@ object AimConfig {
     @JvmField var predictionStep = 0.04     // seconds between trajectory samples
 
     /** Flywheel spins up when estimated time to a launch zone is below this (seconds). */
-    @JvmField var spinupLeadTime = 2.2
+    @JvmField var spinupLeadTime = 1.5
 
     /** Start decelerating trajectory when within this distance of a shooting zone (m). */
     @JvmField var decelZoneMargin = 0.25

--- a/TeamCode/src/main/java/sigmacorns/logic/AutomationManager.kt
+++ b/TeamCode/src/main/java/sigmacorns/logic/AutomationManager.kt
@@ -1,9 +1,12 @@
 package sigmacorns.logic
 
+import com.qualcomm.robotcore.hardware.Gamepad
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.yield
+import org.joml.Vector2d
 import sigmacorns.Robot
 import sigmacorns.constants.FieldLandmarks
 import sigmacorns.constants.robotSize
@@ -11,30 +14,49 @@ import sigmacorns.math.Pose2d
 import sigmacorns.math.closestPointOnConvexPolygon
 import sigmacorns.math.normalizeAngle
 import sigmacorns.sim.MecanumState
+import sigmacorns.subsystem.IntakeTransfer
 import kotlin.math.absoluteValue
+import kotlin.math.hypot
 import kotlin.math.max
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
-class AutomationManager() {
+class AutomationManager(val robot: Robot) {
+    companion object {
+        private val Double.f get() = "%.3f".format(this)
+    }
     var hasControl: Boolean = false
     var curBehavior: Job? = null
 
-    suspend fun update() {
+    fun update(gamepad: Gamepad): Boolean {
+        val lx = gamepad.left_stick_x
+        val ly = gamepad.left_stick_y
+        val rx = gamepad.right_stick_x
+
+        if(max(hypot(lx,ly),rx.absoluteValue) > 0.1 || gamepad.left_stick_button || gamepad.right_stick_button) {
+            hasControl = false
+        }
+
         if(!hasControl) {
-            curBehavior?.cancelAndJoin()
+            curBehavior?.cancel()
             curBehavior = null
-            return
+            return hasControl
         }
 
         if(curBehavior?.isCompleted == true) {
             curBehavior = null
             hasControl = false
         }
+
+        return hasControl
     }
 
     private val MIN_FAR_ZONE_Y = -FieldLandmarks.fieldHalfExtend + max(robotSize.x,robotSize.y)
 
-    fun shootFarZone(robot: Robot) {
+
+    fun shootFarZone() {
+        if(curBehavior != null) return
+
         curBehavior = robot.scope.launch {
             val p = closestPointOnConvexPolygon(FieldLandmarks.farZoneCorners, robot.io.position().v)
             val curTheta = robot.io.position().rot
@@ -54,30 +76,107 @@ class AutomationManager() {
             }
 
             val target = MecanumState(Pose2d(),Pose2d(p,theta))
+            println("[NativeAutoAim] " + "shootFarZone: target=(${p.x.f},${p.y.f}) heading=${Math.toDegrees(theta).f}°")
 
             val beforeAutoShoot = robot.intakeCoordinator.autoShootEnabled
             val beforeAimFlywheel = robot.aimFlywheel
             val beforeAimTurret = robot.aimTurret
+            val beforeFieldCentric = robot.drive.fieldCentric
             robot.intakeCoordinator.autoShootEnabled = true
             robot.aimFlywheel = true
             robot.aimTurret = true
+            robot.drive.fieldCentric = false
+            val curPos = robot.io.position().v
+            val curVel = robot.io.velocity().v
+            val dist = hypot(p.x - curPos.x, p.y - curPos.y)
+            val speed = hypot(curVel.x, curVel.y).coerceAtLeast(0.5)
+            val timeToArrival = (dist / speed).seconds
+            println("[NativeAutoAim] " + "shootFarZone: dist=${dist.f}m speed=${speed.f}m/s eta=${timeToArrival.inWholeMilliseconds}ms")
 
-            val pathing = launch {
-                robot.ltv.runWaypointToCompletion(target,5.seconds,robot.io)
-                while (true) {
-                    robot.ltv.holdPos(robot.io,target.pos)
-                    yield()
-                }
-            }
+            var holding = false
+            var pathingUpdatedEta = false
+            lateinit var pathing: Job
 
             try {
-                while (robot.beamBreak.ballCount>0) yield()
+                pathing = launch {
+                    pathingUpdatedEta = true
+                    robot.ltv.runWaypointToCompletion(target,5.seconds,robot.io)
+                    println("[NativeAutoAim] " + "shootFarZone: waypoint reached, now holding")
+                    holding = true
+                    while (true) {
+                        robot.ltv.holdPos(robot.io,target.pos)
+                        yield()
+                    }
+                }
+                while (robot.beamBreak.ballCount > 0) {
+                    // Compute ETA for NativeAutoAim's trajectory interpolation.
+                    // prevWaypointEta() can collapse to 0 if the solver's horizon
+                    // shrinks; fall back to distance/velocity when that happens
+                    // to prevent NativeAutoAim from aiming at a phantom position.
+                    val solverEta = robot.ltv.prevWaypointEta()
+                    val pos = robot.io.position().v
+                    val d = hypot(target.pos.v.x - pos.x, target.pos.v.y - pos.y)
+                    val distEta = (d / hypot(robot.io.velocity().v.x, robot.io.velocity().v.y).coerceAtLeast(0.5)).seconds
+                    val eta = when {
+                        holding -> 0.seconds
+                        !pathingUpdatedEta -> timeToArrival
+                        d > 0.1 -> maxOf(solverEta, distEta)
+                        else -> solverEta
+                    }
+                    robot.aim.plannedShot = PlannedShot(target, eta)
+                    println("[NativeAutoAim] " + "shootFarZone: balls=${robot.beamBreak.ballCount} holding=$holding eta=${eta.inWholeMilliseconds}ms inZone=${robot.intakeCoordinator.inShootingZone} readyToShoot=${robot.aim.readyToShoot}")
+                    yield()
+                }
+                println("[NativeAutoAim] " + "shootFarZone: all balls fired")
             } finally {
                 pathing.cancelAndJoin()
+                robot.aim.plannedShot = null
                 robot.intakeCoordinator.autoShootEnabled = beforeAutoShoot
                 robot.aimFlywheel = beforeAimFlywheel
                 robot.aimTurret = beforeAimTurret
+                robot.drive.fieldCentric = beforeFieldCentric
+                // Zero drive commands — the cancelled pathing coroutine's final
+                // iteration writes stale LTV outputs after manual drive has already
+                // written to IO, so overwrite them to prevent one frame of stale drive.
+                robot.io.driveFL = 0.0
+                robot.io.driveBL = 0.0
+                robot.io.driveBR = 0.0
+                robot.io.driveFR = 0.0
             }
         }
+
+        hasControl = true
+    }
+
+    fun intakeGate(timeout: Duration = Duration.INFINITE) {
+        if(curBehavior != null) return
+
+        curBehavior = robot.scope.launch {
+            val beforeFieldCentric = robot.drive.fieldCentric
+            robot.drive.fieldCentric = false
+            val p = FieldLandmarks.gateIntakePosition(robot.blue)
+            val target = MecanumState(Pose2d(),p)
+
+            try {
+                robot.ltv.runWaypointToCompletion(target, 5.seconds, robot.io, posTol = 0.1)
+                robot.intakeTransfer.state = IntakeTransfer.State.INTAKING
+
+                withTimeout(timeout) {
+                    while (!robot.beamBreak.isFull) {
+                        robot.ltv.holdPos(robot.io, p)
+                        yield()
+                    }
+                }
+            } finally {
+                robot.intakeTransfer.state = IntakeTransfer.State.IDLE
+                robot.drive.fieldCentric = beforeFieldCentric
+                robot.io.driveFL = 0.0
+                robot.io.driveBL = 0.0
+                robot.io.driveBR = 0.0
+                robot.io.driveFR = 0.0
+            }
+        }
+
+        hasControl = true
     }
 }

--- a/TeamCode/src/main/java/sigmacorns/logic/AutomationManager.kt
+++ b/TeamCode/src/main/java/sigmacorns/logic/AutomationManager.kt
@@ -1,0 +1,83 @@
+package sigmacorns.logic
+
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.yield
+import sigmacorns.Robot
+import sigmacorns.constants.FieldLandmarks
+import sigmacorns.constants.robotSize
+import sigmacorns.math.Pose2d
+import sigmacorns.math.closestPointOnConvexPolygon
+import sigmacorns.math.normalizeAngle
+import sigmacorns.sim.MecanumState
+import kotlin.math.absoluteValue
+import kotlin.math.max
+import kotlin.time.Duration.Companion.seconds
+
+class AutomationManager() {
+    var hasControl: Boolean = false
+    var curBehavior: Job? = null
+
+    suspend fun update() {
+        if(!hasControl) {
+            curBehavior?.cancelAndJoin()
+            curBehavior = null
+            return
+        }
+
+        if(curBehavior?.isCompleted == true) {
+            curBehavior = null
+            hasControl = false
+        }
+    }
+
+    private val MIN_FAR_ZONE_Y = -FieldLandmarks.fieldHalfExtend + max(robotSize.x,robotSize.y)
+
+    fun shootFarZone(robot: Robot) {
+        curBehavior = robot.scope.launch {
+            val p = closestPointOnConvexPolygon(FieldLandmarks.farZoneCorners, robot.io.position().v)
+            val curTheta = robot.io.position().rot
+            p.y = max(p.y, MIN_FAR_ZONE_Y)
+
+            // bc this is far zone bounds will always be in -PI to PI
+            val goalAngle = p.angle(FieldLandmarks.goalPosition(robot.blue))
+            val headingRange = (robot.turret.angleLimits.start*0.8 + goalAngle)..(robot.turret.angleLimits.endInclusive*0.8 + goalAngle)
+
+            val errStart = normalizeAngle(headingRange.start-curTheta).absoluteValue
+            val errEnd = normalizeAngle(headingRange.endInclusive-curTheta).absoluteValue
+
+            val theta = if(headingRange.contains(curTheta)) {
+                curTheta
+            } else {
+                if(errStart < errEnd) headingRange.start else headingRange.endInclusive
+            }
+
+            val target = MecanumState(Pose2d(),Pose2d(p,theta))
+
+            val beforeAutoShoot = robot.intakeCoordinator.autoShootEnabled
+            val beforeAimFlywheel = robot.aimFlywheel
+            val beforeAimTurret = robot.aimTurret
+            robot.intakeCoordinator.autoShootEnabled = true
+            robot.aimFlywheel = true
+            robot.aimTurret = true
+
+            val pathing = launch {
+                robot.ltv.runWaypointToCompletion(target,5.seconds,robot.io)
+                while (true) {
+                    robot.ltv.holdPos(robot.io,target.pos)
+                    yield()
+                }
+            }
+
+            try {
+                while (robot.beamBreak.ballCount>0) yield()
+            } finally {
+                pathing.cancelAndJoin()
+                robot.intakeCoordinator.autoShootEnabled = beforeAutoShoot
+                robot.aimFlywheel = beforeAimFlywheel
+                robot.aimTurret = beforeAimTurret
+            }
+        }
+    }
+}

--- a/TeamCode/src/main/java/sigmacorns/logic/AutomationManager.kt
+++ b/TeamCode/src/main/java/sigmacorns/logic/AutomationManager.kt
@@ -2,11 +2,11 @@ package sigmacorns.logic
 
 import com.qualcomm.robotcore.hardware.Gamepad
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.yield
 import org.joml.Vector2d
+import org.joml.minus
 import sigmacorns.Robot
 import sigmacorns.constants.FieldLandmarks
 import sigmacorns.constants.robotSize
@@ -48,35 +48,70 @@ class AutomationManager(val robot: Robot) {
             hasControl = false
         }
 
+        if(curBehavior?.isCancelled == true) {
+            curBehavior = null
+            hasControl = false
+        }
+
         return hasControl
     }
 
     private val MIN_FAR_ZONE_Y = -FieldLandmarks.fieldHalfExtend + max(robotSize.x,robotSize.y)
 
+    private fun target(polygon: List<Vector2d>): MecanumState {
+        val p = closestPointOnConvexPolygon(polygon, robot.io.position().v)
+        val curTheta = robot.io.position().rot
+        p.y = max(p.y, MIN_FAR_ZONE_Y)
 
-    fun shootFarZone() {
-        if(curBehavior != null) return
+        // bc this is far zone bounds will always be in -PI to PI
+        val goalAngle = p.angle(FieldLandmarks.goalPosition(robot.blue))
+        val headingRange = (robot.turret.angleLimits.start*0.8 + goalAngle)..(robot.turret.angleLimits.endInclusive*0.8 + goalAngle)
+
+        val errStart = normalizeAngle(headingRange.start-curTheta).absoluteValue
+        val errEnd = normalizeAngle(headingRange.endInclusive-curTheta).absoluteValue
+
+        val theta = if(headingRange.contains(curTheta)) {
+            curTheta
+        } else {
+            if(errStart < errEnd) headingRange.start else headingRange.endInclusive
+        }
+
+        return MecanumState(Pose2d(),Pose2d(p,theta))
+    }
+
+    private fun tryLock(): Boolean {
+        if(curBehavior != null && curBehavior!!.isActive) {
+            curBehavior?.cancel()
+            return false
+        }
+        return true
+    }
+
+    private var holding = false
+    private var staleETA = false
+    private suspend fun ltvMoveHold(target: MecanumState) {
+        try {
+            staleETA = false
+            robot.ltv.runWaypointToCompletion(target,5.seconds,robot.io)
+            holding = true
+            while (true) {
+                robot.ltv.holdPos(robot.io,target.pos)
+                yield()
+            }
+        } finally {
+            staleETA = true
+            holding = false
+        }
+    }
+
+    fun shootFarZone() = shootZone(FieldLandmarks.farZoneCorners)
+    fun shootGoalZone() = shootZone(FieldLandmarks.goalZoneCorners)
+
+    private fun shootZone(corners: List<Vector2d>) {
+        if(!tryLock()) return
 
         curBehavior = robot.scope.launch {
-            val p = closestPointOnConvexPolygon(FieldLandmarks.farZoneCorners, robot.io.position().v)
-            val curTheta = robot.io.position().rot
-            p.y = max(p.y, MIN_FAR_ZONE_Y)
-
-            // bc this is far zone bounds will always be in -PI to PI
-            val goalAngle = p.angle(FieldLandmarks.goalPosition(robot.blue))
-            val headingRange = (robot.turret.angleLimits.start*0.8 + goalAngle)..(robot.turret.angleLimits.endInclusive*0.8 + goalAngle)
-
-            val errStart = normalizeAngle(headingRange.start-curTheta).absoluteValue
-            val errEnd = normalizeAngle(headingRange.endInclusive-curTheta).absoluteValue
-
-            val theta = if(headingRange.contains(curTheta)) {
-                curTheta
-            } else {
-                if(errStart < errEnd) headingRange.start else headingRange.endInclusive
-            }
-
-            val target = MecanumState(Pose2d(),Pose2d(p,theta))
-            println("[NativeAutoAim] " + "shootFarZone: target=(${p.x.f},${p.y.f}) heading=${Math.toDegrees(theta).f}°")
+            val target = target(corners)
 
             val beforeAutoShoot = robot.intakeCoordinator.autoShootEnabled
             val beforeAimFlywheel = robot.aimFlywheel
@@ -86,28 +121,18 @@ class AutomationManager(val robot: Robot) {
             robot.aimFlywheel = true
             robot.aimTurret = true
             robot.drive.fieldCentric = false
+
+            // simple constant-vel approx
             val curPos = robot.io.position().v
             val curVel = robot.io.velocity().v
-            val dist = hypot(p.x - curPos.x, p.y - curPos.y)
+            val dist = (target.pos.v - curPos).length()
             val speed = hypot(curVel.x, curVel.y).coerceAtLeast(0.5)
             val timeToArrival = (dist / speed).seconds
-            println("[NativeAutoAim] " + "shootFarZone: dist=${dist.f}m speed=${speed.f}m/s eta=${timeToArrival.inWholeMilliseconds}ms")
 
-            var holding = false
-            var pathingUpdatedEta = false
             lateinit var pathing: Job
 
             try {
-                pathing = launch {
-                    pathingUpdatedEta = true
-                    robot.ltv.runWaypointToCompletion(target,5.seconds,robot.io)
-                    println("[NativeAutoAim] " + "shootFarZone: waypoint reached, now holding")
-                    holding = true
-                    while (true) {
-                        robot.ltv.holdPos(robot.io,target.pos)
-                        yield()
-                    }
-                }
+                pathing = launch { ltvMoveHold(target) }
                 while (robot.beamBreak.ballCount > 0) {
                     // Compute ETA for NativeAutoAim's trajectory interpolation.
                     // prevWaypointEta() can collapse to 0 if the solver's horizon
@@ -119,7 +144,7 @@ class AutomationManager(val robot: Robot) {
                     val distEta = (d / hypot(robot.io.velocity().v.x, robot.io.velocity().v.y).coerceAtLeast(0.5)).seconds
                     val eta = when {
                         holding -> 0.seconds
-                        !pathingUpdatedEta -> timeToArrival
+                        staleETA -> timeToArrival
                         d > 0.1 -> maxOf(solverEta, distEta)
                         else -> solverEta
                     }
@@ -129,7 +154,7 @@ class AutomationManager(val robot: Robot) {
                 }
                 println("[NativeAutoAim] " + "shootFarZone: all balls fired")
             } finally {
-                pathing.cancelAndJoin()
+                pathing.cancel()
                 robot.aim.plannedShot = null
                 robot.intakeCoordinator.autoShootEnabled = beforeAutoShoot
                 robot.aimFlywheel = beforeAimFlywheel

--- a/TeamCode/src/main/java/sigmacorns/logic/IntakeCoordinator.kt
+++ b/TeamCode/src/main/java/sigmacorns/logic/IntakeCoordinator.kt
@@ -75,7 +75,10 @@ class IntakeCoordinator(val robot: Robot) {
         }
 
         if(robot.aimFlywheel && robot.aim.shotRequested) {
-            robot.intakeTransfer.state = if(robot.aim.readyToShoot) IntakeTransfer.State.TRANSFERRING else IntakeTransfer.State.IDLE
+             if(robot.aim.readyToShoot)
+                 robot.intakeTransfer.state = IntakeTransfer.State.TRANSFERRING
+            else if(robot.intakeTransfer.state == IntakeTransfer.State.TRANSFERRING)
+                 robot.intakeTransfer.state = IntakeTransfer.State.IDLE
         }
     }
 

--- a/TeamCode/src/main/java/sigmacorns/logic/IntakeCoordinator.kt
+++ b/TeamCode/src/main/java/sigmacorns/logic/IntakeCoordinator.kt
@@ -6,6 +6,7 @@ import sigmacorns.constants.robotSize
 import sigmacorns.constants.turretPos
 import sigmacorns.math.PolygonOverlapDetection
 import sigmacorns.subsystem.IntakeTransfer
+import kotlin.math.PI
 import kotlin.math.cos
 import kotlin.math.sin
 
@@ -50,23 +51,31 @@ class IntakeCoordinator(val robot: Robot) {
 
         // Auto-shoot zone detection
         if (autoShootEnabled) {
-            val shooterAtSpeed = flywheelTarget > 0.0 &&
-                kotlin.math.abs(flywheelVel - flywheelTarget) < FLYWHEEL_MIN_VEL
+            if(robot.aimFlywheel) {
+                robot.aim.shotRequested = inShootingZone
+            } else {
+                val shooterAtSpeed = flywheelTarget > 0.0 &&
+                        kotlin.math.abs(flywheelVel - flywheelTarget) < FLYWHEEL_MIN_VEL
 
-            if (inShootingZone && shooterAtSpeed) {
-                // In zone and ready — transfer immediately (blocker already open from pre-open below)
-                robot.intakeTransfer.state = IntakeTransfer.State.TRANSFERRING
-            } else if (shooterAtSpeed) {
-                // Flywheel at speed but not yet in zone — pre-open blocker so entry is instant
-                robot.intakeTransfer.state = IntakeTransfer.State.READY_TO_SHOOT
-            } else if (inShootingZone) {
-                // In zone but shooter still spinning up — hold blocker open, wait for speed
-                robot.intakeTransfer.state = IntakeTransfer.State.READY_TO_SHOOT
-            } else if (robot.intakeTransfer.state == IntakeTransfer.State.READY_TO_SHOOT
+                if (inShootingZone && shooterAtSpeed) {
+                    // In zone and ready — transfer immediately (blocker already open from pre-open below)
+                    robot.intakeTransfer.state = IntakeTransfer.State.TRANSFERRING
+                } else if (shooterAtSpeed) {
+                    // Flywheel at speed but not yet in zone — pre-open blocker so entry is instant
+                    robot.intakeTransfer.state = IntakeTransfer.State.READY_TO_SHOOT
+                } else if (inShootingZone) {
+                    // In zone but shooter still spinning up — hold blocker open, wait for speed
+                    robot.intakeTransfer.state = IntakeTransfer.State.READY_TO_SHOOT
+                } else if (robot.intakeTransfer.state == IntakeTransfer.State.READY_TO_SHOOT
                     || robot.intakeTransfer.state == IntakeTransfer.State.TRANSFERRING
-                || (flywheelVel > FLYWHEEL_MIN_VEL && robot.intakeTransfer.state == IntakeTransfer.State.INTAKING)) {
-                robot.intakeTransfer.state = IntakeTransfer.State.IDLE
+                    || (flywheelVel > FLYWHEEL_MIN_VEL && robot.intakeTransfer.state == IntakeTransfer.State.INTAKING)) {
+                    robot.intakeTransfer.state = IntakeTransfer.State.IDLE
+                }
             }
+        }
+
+        if(robot.aimFlywheel && robot.aim.shotRequested) {
+            robot.intakeTransfer.state = if(robot.aim.readyToShoot) IntakeTransfer.State.TRANSFERRING else IntakeTransfer.State.IDLE
         }
     }
 

--- a/TeamCode/src/main/java/sigmacorns/logic/NativeAutoAim.kt
+++ b/TeamCode/src/main/java/sigmacorns/logic/NativeAutoAim.kt
@@ -17,6 +17,7 @@ import sigmacorns.io.HardwareIO
 import sigmacorns.io.rotate
 import sigmacorns.math.Pose2d
 import sigmacorns.math.closestPointOnConvexPolygon
+import sigmacorns.subsystem.IntakeTransfer
 import sigmacorns.subsystem.ShooterConfig
 import sigmacorns.subsystem.TurretServoConfig
 import kotlin.math.PI
@@ -398,10 +399,14 @@ class NativeAutoAim(
             turret.fieldTargetAngle = targetTheta
         }
 
+        val prespin = timeToZone <= AimConfig.spinupLeadTime &&
+                nBalls>0 &&
+                robot.intakeTransfer.state != IntakeTransfer.State.INTAKING
+
         if (robot.aimFlywheel) {
             shooter.hoodAngle = targetPhi
             // Only spin up the flywheel when close enough to a launch zone
-            shooter.flywheelTarget = if (timeToZone <= AimConfig.spinupLeadTime || burstActive)
+            shooter.flywheelTarget = if (prespin || burstActive)
                 targetOmega else 0.0
         }
 

--- a/TeamCode/src/main/java/sigmacorns/logic/NativeAutoAim.kt
+++ b/TeamCode/src/main/java/sigmacorns/logic/NativeAutoAim.kt
@@ -7,13 +7,10 @@ import sigmacorns.constants.ballExitRadius
 import sigmacorns.constants.flywheelMotor
 import sigmacorns.constants.flywheelRadius
 import sigmacorns.constants.turretPos
-import sigmacorns.control.aim.ApproachPrepositioner
 import sigmacorns.control.aim.AutoAim
 import sigmacorns.control.aim.Ballistics
 import sigmacorns.control.aim.TurretPlannerBridge
-import sigmacorns.control.aim.TurretPlannerBridge.OptimalTIdx
-import sigmacorns.control.aim.TurretPlannerBridge.PrepositionIdx
-import sigmacorns.control.aim.TurretPlannerBridge.RobustShotIdx
+import sigmacorns.control.aim.TurretPlannerBridge.Robust3ShotPlanIdx
 import sigmacorns.control.localization.GTSAMEstimator
 import sigmacorns.control.localization.VisionTracker
 import sigmacorns.io.HardwareIO
@@ -29,12 +26,9 @@ import kotlin.time.Duration
 /**
  * Auto-aim implementation backed by the C++ turret_planner library (JNI).
  *
- * Uses the same GTSAM sensor fusion and VisionTracker as [AimingSystem], but
- * replaces the Kotlin Piyavskii-Shubert solver with the native [TurretPlannerBridge].
- * On the first frame (or after a large target change) a cold Piyavskii-Shubert search
- * is run; subsequent frames use a warm Newton refinement for low latency.
- *
- * Swap in [sigmacorns.Robot] by passing `useNativeAim = true`.
+ * Uses the trajectory-aware `robust3ShotPlan` solver to plan up to 3
+ * consecutive shots. During a burst, tracks which shot is next and
+ * switches flywheel/hood/turret targets immediately after each ball exits.
  */
 class NativeAutoAim(
     private val robot: Robot,
@@ -42,7 +36,7 @@ class NativeAutoAim(
 ) : AutoAim {
 
     // ------------------------------------------------------------------
-    // Sensor fusion (same as AimingSystem)
+    // Sensor fusion
     // ------------------------------------------------------------------
 
     override lateinit var autoAim: GTSAMEstimator
@@ -67,25 +61,16 @@ class NativeAutoAim(
 
     private val bridge = TurretPlannerBridge()
 
-    /** Approach-prepositioning helper, lazily created when [AimConfig.prepositionHorizon] > 0. */
-    private var prepositioner: ApproachPrepositioner? = null
-
-    /** Warm-start T* from the previous frame; null → cold start. */
-    private var lastTStar: Float? = null
-
-    /** Solver outputs from the last feasible frame. */
+    /** Solver outputs from the last feasible frame (the NEXT shot to fire). */
     private var lastTheta: Float = 0f
     private var lastPhi:   Float = 0f
     private var lastOmega: Float = 0f
 
-    /** Second-shot leg for the most recent robust solve. */
-    private var lastTheta2: Float = 0f
-    private var lastPhi2:   Float = 0f
-    private var lastOmega2: Float = 0f
-
     override var primaryShotState: Ballistics.ShotState? = null
         private set
     override var secondaryShotState: Ballistics.ShotState? = null
+        private set
+    override var tertiaryShotState: Ballistics.ShotState? = null
         private set
     override var isRobustActive: Boolean = false
         private set
@@ -93,13 +78,32 @@ class NativeAutoAim(
         private set
 
     // ------------------------------------------------------------------
-    // Native config arrays (built once in init, constant thereafter)
+    // Burst sequencing state
     // ------------------------------------------------------------------
 
-    private lateinit var physConfig:  FloatArray   // [g, rH]
-    private lateinit var bounds:      FloatArray   // [thetaMin, thetaMax, phiMin, phiMax, vExitMax, omegaMax]
-    private lateinit var weights:     FloatArray   // [wTheta, wPhi, wOmega]
-    private lateinit var omegaCoeffs: FloatArray   // [c0..c5] for ω(φ,v) = c1·v  (linear in vExit)
+    /** True while we're firing a multi-shot burst. */
+    private var burstActive: Boolean = false
+
+    /** Ball count when the burst started. Ball exits are detected by comparing current count. */
+    private var burstStartBallCount: Int = 0
+
+    /** How many balls have exited so far in this burst. */
+    private var burstShotsFired: Int = 0
+
+    /** Total shots intended in this burst. */
+    private var burstTotalShots: Int = 0
+
+    /** Timestamp of the most recent ball exit. Null before the first ball fires. */
+    private var lastBallExitTime: Duration? = null
+
+    // ------------------------------------------------------------------
+    // Native config arrays
+    // ------------------------------------------------------------------
+
+    private lateinit var physConfig:  FloatArray
+    private lateinit var bounds:      FloatArray
+    private lateinit var weights:     FloatArray
+    private lateinit var omegaCoeffs: FloatArray
 
     // ------------------------------------------------------------------
     // Tolerances for readyToShoot
@@ -128,11 +132,12 @@ class NativeAutoAim(
         autoAim.enabled = true
 
         val omegaMax = flywheelMotor.freeSpeed
-        val vMax = omegaMax*flywheelRadius* AimConfig.launchEfficiency
+        val vMax = omegaMax * flywheelRadius * AimConfig.launchEfficiency
 
         physConfig = floatArrayOf(
             AimConfig.g.toFloat(),
-            ballExitRadius.toFloat()
+            ballExitRadius.toFloat(),
+            AimConfig.dragK.toFloat()
         )
 
         bounds = floatArrayOf(
@@ -150,15 +155,9 @@ class NativeAutoAim(
             ShotSolverConfig.wOmega.toFloat()
         )
 
-        // omega(phi, vExit) = c1 * vExit  where c1 = 1 / (flywheelRadius * launchEfficiency)
         val c1 = (1.0 / (flywheelRadius * AimConfig.launchEfficiency)).toFloat()
         omegaCoeffs = floatArrayOf(0f, c1, 0f, 0f, 0f, 0f)
 
-        prepositioner = if (AimConfig.prepositionHorizon > 0.0) {
-            ApproachPrepositioner(bridge, weights, bounds, physConfig, omegaCoeffs)
-        } else {
-            null
-        }
     }
 
     override fun update(dt: Duration, aimTurret: Boolean) {
@@ -197,14 +196,53 @@ class NativeAutoAim(
         val shooter = robot.shooter
         val turret  = robot.turret
         val fusedPose = autoAim.fusedPose
+        val now = robot.io.time()
 
         val nBalls = robot.beamBreak.ballCount
+
+        // ── Burst sequencing: detect ball exits ──────────────────────────
+        if (burstActive) {
+            val ballsFiredSoFar = burstStartBallCount - nBalls
+            if (ballsFiredSoFar > burstShotsFired) {
+                // A ball just exited
+                burstShotsFired = ballsFiredSoFar
+                lastBallExitTime = now
+                // Immediately start transferring the next ball if any remain
+                if (burstShotsFired < burstTotalShots && nBalls > 0) {
+                    robot.intakeTransfer.state = IntakeTransfer.State.TRANSFERRING
+                }
+            }
+            // Burst complete
+            if (burstShotsFired >= burstTotalShots || nBalls == 0) {
+                burstActive = false
+                burstShotsFired = 0
+                lastBallExitTime = null
+            }
+        }
+
+        // ── Compute t_remaining ──────────────────────────────────────────
+        // Time until the next ball can physically exit the shooter.
+        //   Not in burst: transferDelay (ball needs full transfer to reach flywheel)
+        //   In burst, first ball not yet fired: transferDelay (same)
+        //   In burst, after a ball exited: transferDelay - elapsed since exit
+        val tRemaining: Float = if (burstActive && lastBallExitTime != null) {
+            val elapsed = (now - lastBallExitTime!!).inWholeMilliseconds / 1000.0
+            (AimConfig.transferDelay - elapsed).coerceAtLeast(0.0).toFloat()
+        } else {
+            AimConfig.transferDelay.toFloat()
+        }
+
+        // How many balls remain to plan for
+        val remainingBalls = if (burstActive) {
+            (burstTotalShots - burstShotsFired).coerceIn(1, nBalls)
+        } else {
+            nBalls.coerceAtLeast(1)
+        }
 
         // Robot velocity in field frame
         val odoVel = Vector2d(robot.io.velocity().v)
         val vel = odoVel.rotate(fusedPose.rot - robot.io.position().rot)
 
-        // Turret position in field frame (ignore small robot-frame offset)
         val tX = fusedPose.v.x.toFloat()
         val tY = fusedPose.v.y.toFloat()
         val tZ = turretPos.z.toFloat()
@@ -217,17 +255,14 @@ class NativeAutoAim(
         val robotVx = vel.x.toFloat()
         val robotVy = vel.y.toFloat()
 
-        // Current actuator state
         val curTheta = (turret.pos + fusedPose.rot).toFloat()
         val curPhi   = shooter.computedHoodAngle.toFloat()
         val curOmega = robot.io.flywheelVelocity().toFloat()
 
-        val flywheelDrop = (nBalls-1)*AimConfig.flywheelDrop.toFloat()
-
-        // ── Launch-zone split ─────────────────────────────────────────────
-        // Half-plane: nx*x + ny*y >= d means "inside the launch zone".
-        // When both normal components are 0, the feature is disabled and we
-        // fall through to the legacy instant / robustShot path unconditionally.
+        // ── Launch-zone: compute effective t_remaining ────────────────────
+        // When outside a defined zone, inflate t_remaining so urgency drops
+        // to ~0 and the solver optimizes purely for inter-shot robustness.
+        // The turret slews toward s1 naturally over the approach time.
         val zoneNx = AimConfig.launchZoneNx
         val zoneNy = AimConfig.launchZoneNy
         val zoneD  = AimConfig.launchZoneD
@@ -237,133 +272,104 @@ class NativeAutoAim(
                      else Double.POSITIVE_INFINITY
         val inZone = zoneZ0 >= 0.0
 
-        var solved = false
-        var robustSolved = false
-
-        var prepositioned = false
-        isRobustActive = false
-        isPrepositionActive = false
-        if (zoneDefined && !inZone) {
-            // ── Outside the launch zone: preposition with t_until_zone ────
-            // Half-plane approach time: z0 = n·p − d, z0(t) = z0 + (n·v)·t.
-            // We want z0(t_cross) = 0, so t_cross = −z0 / (n·v), valid when
-            // the robot is actually moving toward the zone (n·v > 0).
+        val effectiveTRemaining: Float = if (zoneDefined && !inZone && !burstActive) {
+            // Outside the zone: estimate time until zone entry, add transfer delay.
+            // With high t_remaining, w_urgency → 0 so J_0 doesn't matter.
             val nDotV = zoneNx * vel.x + zoneNy * vel.y
-            val tUntilZone = if (nDotV > 1e-3) {
-                (-zoneZ0 / nDotV).coerceAtLeast(0.0)
-            } else {
-                // Not heading into the zone — give a generous slew budget so
-                // the preposition doesn't over-clamp. This keeps the turret
-                // prepared in case the driver reverses course.
-                AimConfig.prepositionTAvailable
-            }
-            val prep = prepositioner?.compute(
-                robotPose = fusedPose,
-                robotVel = Vector2d(vel.x, vel.y),
-                goal = goal,
-                turretZ = turretPos.z,
-                curTheta = curTheta.toDouble(),
-                curPhi = curPhi.toDouble(),
-                curOmega = curOmega.toDouble(),
-                omegaDrop = AimConfig.flywheelDrop,
-                horizonSeconds = AimConfig.prepositionHorizon,
-                steps = AimConfig.prepositionSteps,
-                lambdaDecay = AimConfig.prepositionLambda,
-                tAvailable = tUntilZone,
-            )
-            if (prep != null) {
-                lastTStar = null
-                lastTheta = prep[PrepositionIdx.THETA]
-                lastPhi   = prep[PrepositionIdx.PHI]
-                lastOmega = prep[PrepositionIdx.OMEGA]
-                prepositioned = true
-                isPrepositionActive = true
-                // `solved` stays false — preposition is a pre-aim, not a shot.
-            }
+            val tUntilZone = if (nDotV > 1e-3) (-zoneZ0 / nDotV).coerceAtLeast(0.0)
+                             else AimConfig.prepositionTAvailable
+            (tUntilZone + AimConfig.transferDelay).toFloat()
         } else {
-            // ── No launch zone defined: legacy behavior ───────────────────
-            val useRobust = flywheelDrop > 0 && robot.intakeTransfer.state != IntakeTransfer.State.TRANSFERRING
-            try {
-                if (useRobust) {
-                    val r = bridge.robustShot(
-                        tX, tY, tZ,
-                        gX, gY, gZ,
-                        gX, gY, gZ,
-                        robotVx, robotVy,
-                        flywheelDrop,
-                        weights, bounds, physConfig, omegaCoeffs
-                    )
-                    if (r[RobustShotIdx.FEASIBLE] > 0.5f) {
-                        lastTStar = r[RobustShotIdx.T1]
-                        lastTheta = r[RobustShotIdx.S1_THETA]
-                        lastPhi   = r[RobustShotIdx.S1_PHI]
-                        lastOmega = r[RobustShotIdx.S1_OMEGA]
-                        lastTheta2 = r[RobustShotIdx.S2_THETA]
-                        lastPhi2   = r[RobustShotIdx.S2_PHI]
-                        lastOmega2 = r[RobustShotIdx.S2_OMEGA]
-                        solved = true
-                        robustSolved = true
-                    }
-                }
-
-                if(!robustSolved){
-                    val tStar = lastTStar
-                    val result = if (tStar != null) {
-                        bridge.optimalTWarm(
-                            tX, tY, tZ,
-                            gX, gY, gZ,
-                            robotVx, robotVy,
-                            tStar,
-                            curTheta, curPhi, curOmega,
-                            weights, bounds, physConfig, omegaCoeffs
-                        )
-                    } else {
-                        bridge.optimalTCold(
-                            tX, tY, tZ,
-                            gX, gY, gZ,
-                            robotVx, robotVy,
-                            curTheta, curPhi, curOmega,
-                            weights, bounds, physConfig, omegaCoeffs
-                        )
-                    }
-                    if (result[OptimalTIdx.FEASIBLE] > 0.5f) {
-                        lastTStar = result[OptimalTIdx.T_STAR]
-                        lastTheta = result[OptimalTIdx.THETA]
-                        lastPhi   = result[OptimalTIdx.PHI]
-                        lastOmega = result[OptimalTIdx.OMEGA]
-                        solved = true
-                    }
-                }
-            } catch (e: Exception) {
-                // leaves last* untouched; readyToShoot set false below
-            }
+            tRemaining
         }
 
-        if (!solved && !prepositioned) {
-            // No feasible solve this tick and no preposition update — bail out.
-            lastTStar = null
+        var solved = false
+        isRobustActive = false
+        isPrepositionActive = false
+        secondaryShotState = null
+        tertiaryShotState = null
+
+        // ── Trajectory-aware robust solve (used everywhere) ──────────────
+        try {
+            val horizon = AimConfig.transferDelay * remainingBalls + AimConfig.predictionHorizon
+            val step = AimConfig.predictionStep.toFloat()
+            val nSteps = (horizon / step).toInt().coerceIn(2, 60)
+            val trajArray = FloatArray(nSteps * 6)
+            for (i in 0 until nSteps) {
+                val t = i * step
+                trajArray[i * 6 + 0] = t
+                trajArray[i * 6 + 1] = tX + robotVx * t
+                trajArray[i * 6 + 2] = tY + robotVy * t
+                trajArray[i * 6 + 3] = fusedPose.rot.toFloat()
+                trajArray[i * 6 + 4] = robotVx
+                trajArray[i * 6 + 5] = robotVy
+            }
+
+            val r = bridge.robust3ShotPlan(
+                trajArray, nSteps,
+                tZ,
+                gX, gY, gZ,
+                curTheta, curPhi, curOmega,
+                remainingBalls,
+                effectiveTRemaining,
+                AimConfig.transferDelay.toFloat(),
+                AimConfig.dropFraction.toFloat(),
+                AimConfig.urgencyLambda.toFloat(),
+                weights, bounds, physConfig, omegaCoeffs
+            )
+
+            if (r[Robust3ShotPlanIdx.FEASIBLE] > 0.5f) {
+                // The solver found optimal flight times from future trajectory
+                // positions. Re-solve s1 from the CURRENT position using T1 so
+                // the turret theta is correct for right now (not for the future
+                // position). Phi and omega are nearly the same; theta changes
+                // significantly because it depends on the turret-to-goal angle.
+                val T1 = r[Robust3ShotPlanIdx.T1]
+                val nowShot = bridge.solve(
+                    tX, tY, tZ,
+                    gX, gY, gZ,
+                    robotVx, robotVy,
+                    T1,
+                    physConfig, omegaCoeffs
+                )
+                lastTheta = nowShot[TurretPlannerBridge.SolveIdx.THETA]
+                lastPhi   = nowShot[TurretPlannerBridge.SolveIdx.PHI]
+                lastOmega = nowShot[TurretPlannerBridge.SolveIdx.OMEGA]
+                solved = true
+
+                if (remainingBalls >= 2) {
+                    isRobustActive = true
+                    secondaryShotState = Ballistics.ShotState(
+                        theta = r[Robust3ShotPlanIdx.S2_THETA].toDouble(),
+                        phi   = r[Robust3ShotPlanIdx.S2_PHI].toDouble(),
+                        vExit = r[Robust3ShotPlanIdx.S2_OMEGA].toDouble() * flywheelRadius * AimConfig.launchEfficiency,
+                    )
+                }
+                if (remainingBalls >= 3) {
+                    tertiaryShotState = Ballistics.ShotState(
+                        theta = r[Robust3ShotPlanIdx.S3_THETA].toDouble(),
+                        phi   = r[Robust3ShotPlanIdx.S3_PHI].toDouble(),
+                        vExit = r[Robust3ShotPlanIdx.S3_OMEGA].toDouble() * flywheelRadius * AimConfig.launchEfficiency,
+                    )
+                }
+            }
+        } catch (_: Exception) {
+            // leaves last* untouched; readyToShoot set false below
+        }
+
+        if (!solved) {
             readyToShoot = false
             primaryShotState = null
             secondaryShotState = null
+            tertiaryShotState = null
             return
         }
 
-        // Expose the active target(s) as ShotState(theta, phi, vExit) for viz.
         primaryShotState = Ballistics.ShotState(
             theta = lastTheta.toDouble(),
             phi   = lastPhi.toDouble(),
             vExit = lastOmega.toDouble() * flywheelRadius * AimConfig.launchEfficiency,
         )
-        if (robustSolved) {
-            isRobustActive = true
-            secondaryShotState = Ballistics.ShotState(
-                theta = lastTheta2.toDouble(),
-                phi   = lastPhi2.toDouble(),
-                vExit = lastOmega2.toDouble() * flywheelRadius * AimConfig.launchEfficiency,
-            )
-        } else {
-            secondaryShotState = null
-        }
 
         if (aimTurret) {
             turret.fieldRelativeMode = true
@@ -375,8 +381,6 @@ class NativeAutoAim(
             shooter.flywheelTarget = lastOmega.toDouble()
         }
 
-        // Readiness only counts when we have a real shot solve — a preposition
-        // target is a pre-aim, not an alignment to an actual feasible shot.
         if (solved) {
             val thetaErr = abs(wrapAngle(turret.pos + fusedPose.rot - lastTheta))
             val phiErr   = abs(shooter.computedHoodAngle - lastPhi)
@@ -386,7 +390,15 @@ class NativeAutoAim(
             readyToShoot = false
         }
 
+        // ── Fire / burst trigger ─────────────────────────────────────────
         if (shotRequested && readyToShoot) {
+            if (!burstActive) {
+                burstActive = true
+                burstShotsFired = 0
+                burstStartBallCount = nBalls
+                burstTotalShots = nBalls
+                lastBallExitTime = null
+            }
             shotRequested = false
             robot.intakeTransfer.state = IntakeTransfer.State.TRANSFERRING
         }

--- a/TeamCode/src/main/java/sigmacorns/logic/NativeAutoAim.kt
+++ b/TeamCode/src/main/java/sigmacorns/logic/NativeAutoAim.kt
@@ -16,36 +16,34 @@ import sigmacorns.control.localization.VisionTracker
 import sigmacorns.io.HardwareIO
 import sigmacorns.io.rotate
 import sigmacorns.math.Pose2d
-import sigmacorns.subsystem.IntakeTransfer
+import sigmacorns.math.closestPointOnConvexPolygon
 import sigmacorns.subsystem.ShooterConfig
+import sigmacorns.subsystem.TurretServoConfig
 import kotlin.math.PI
 import kotlin.math.abs
 import kotlin.math.hypot
 import kotlin.time.Duration
 
 /**
- * Auto-aim implementation backed by the C++ turret_planner library (JNI).
+ * Auto-aim backed by the C++ turret_planner (JNI).
  *
- * Uses the trajectory-aware `robust3ShotPlan` solver to plan up to 3
- * consecutive shots. During a burst, tracks which shot is next and
- * switches flywheel/hood/turret targets immediately after each ball exits.
+ * Uses `robust3ShotPlan` to plan up to 3 consecutive shots with hard
+ * constraints: J_12 <= transferTime and J_23 <= transferTime ensure the
+ * flywheel can recover between shots. The burst is only triggered when the
+ * solver finds a feasible plan for all loaded balls.
+ *
+ * Zone logic uses [FieldLandmarks.goalZoneCorners] and [FieldLandmarks.farZoneCorners]
+ * to determine if the robot is in a shooting zone. Outside the zone, t_remaining
+ * is inflated so the solver optimizes purely for inter-shot robustness.
  */
 class NativeAutoAim(
     private val robot: Robot,
     private val blue: Boolean,
 ) : AutoAim {
 
-    // ------------------------------------------------------------------
-    // Sensor fusion
-    // ------------------------------------------------------------------
-
     override lateinit var autoAim: GTSAMEstimator
         private set
     private var visionTracker: VisionTracker? = null
-
-    // ------------------------------------------------------------------
-    // AutoAim state
-    // ------------------------------------------------------------------
 
     override var goalPosition: Vector2d = FieldLandmarks.goalPosition(blue)
     override var positionOverride: Double? = null
@@ -55,16 +53,12 @@ class NativeAutoAim(
     override var targetDistance: Double = 3.0
         private set
 
-    // ------------------------------------------------------------------
-    // Native bridge
-    // ------------------------------------------------------------------
-
     private val bridge = TurretPlannerBridge()
 
-    /** Solver outputs from the last feasible frame (the NEXT shot to fire). */
     private var lastTheta: Float = 0f
     private var lastPhi:   Float = 0f
     private var lastOmega: Float = 0f
+    private var lastT1:    Float = 0f
 
     override var primaryShotState: Ballistics.ShotState? = null
         private set
@@ -74,48 +68,28 @@ class NativeAutoAim(
         private set
     override var isRobustActive: Boolean = false
         private set
-    override var isPrepositionActive: Boolean = false
-        private set
 
-    // ------------------------------------------------------------------
-    // Burst sequencing state
-    // ------------------------------------------------------------------
-
-    /** True while we're firing a multi-shot burst. */
-    private var burstActive: Boolean = false
-
-    /** Ball count when the burst started. Ball exits are detected by comparing current count. */
-    private var burstStartBallCount: Int = 0
-
-    /** How many balls have exited so far in this burst. */
-    private var burstShotsFired: Int = 0
-
-    /** Total shots intended in this burst. */
-    private var burstTotalShots: Int = 0
-
-    /** Timestamp of the most recent ball exit. Null before the first ball fires. */
+    // ── Burst sequencing ─────────────────────────────────────────────
+    private var burstActive = false
+    private var burstStartBallCount = 0
+    private var burstShotsFired = 0
+    private var burstTotalShots = 0
     private var lastBallExitTime: Duration? = null
 
-    // ------------------------------------------------------------------
-    // Native config arrays
-    // ------------------------------------------------------------------
+    /** True when the last solve was feasible for all balls (burst is safe to start). */
+    private var allBallsFeasible = false
 
+    // ── Zones (mirrored for alliance) ────────────────────────────────
+    private lateinit var goalZone: List<Vector2d>
+    private lateinit var farZone: List<Vector2d>
+
+    // ── Native config arrays ─────────────────────────────────────────
     private lateinit var physConfig:  FloatArray
     private lateinit var bounds:      FloatArray
     private lateinit var weights:     FloatArray
     private lateinit var omegaCoeffs: FloatArray
 
-    // ------------------------------------------------------------------
-    // Tolerances for readyToShoot
-    // ------------------------------------------------------------------
-
-    private val turretTol = 0.05   // rad
-    private val hoodTol   = 0.05   // rad
-    private val omegaTol  = 50.0   // rad/s
-
-    // ------------------------------------------------------------------
-    // Lifecycle
-    // ------------------------------------------------------------------
+    // ── Lifecycle ────────────────────────────────────────────────────
 
     override fun init(initialPose: Pose2d, apriltagTracking: Boolean) {
         autoAim = GTSAMEstimator(
@@ -128,7 +102,6 @@ class NativeAutoAim(
             limelight = limelight,
             allowedTagIds = FieldLandmarks.landmarkTagIds
         )
-
         autoAim.enabled = true
 
         val omegaMax = flywheelMotor.freeSpeed
@@ -139,50 +112,46 @@ class NativeAutoAim(
             ballExitRadius.toFloat(),
             AimConfig.dragK.toFloat()
         )
-
         bounds = floatArrayOf(
-            (-PI).toFloat(),
-            PI.toFloat(),
+            (-PI).toFloat(), PI.toFloat(),
             Math.toRadians(ShooterConfig.minAngleDeg).toFloat(),
             Math.toRadians(ShooterConfig.maxAngleDeg).toFloat(),
-            vMax.toFloat(),
-            omegaMax.toFloat()
+            vMax.toFloat(), omegaMax.toFloat()
         )
-
         weights = floatArrayOf(
             ShotSolverConfig.wTheta.toFloat(),
             ShotSolverConfig.wPhi.toFloat(),
             ShotSolverConfig.wOmega.toFloat()
         )
-
         val c1 = (1.0 / (flywheelRadius * AimConfig.launchEfficiency)).toFloat()
         omegaCoeffs = floatArrayOf(0f, c1, 0f, 0f, 0f, 0f)
 
+        // Mirror zones for alliance (FieldLandmarks uses red-origin coords)
+        goalZone = FieldLandmarks.goalZoneCorners.map {
+            if (blue) Vector2d(-it.x, it.y) else Vector2d(it)
+        }
+        farZone = FieldLandmarks.farZoneCorners.map {
+            if (blue) Vector2d(-it.x, it.y) else Vector2d(it)
+        }
     }
 
     override fun update(dt: Duration, aimTurret: Boolean) {
         updateVision()
         setTurretInputs()
         setShooterInputs(aimTurret)
-
-        positionOverride?.let { override ->
-            if (robot.turret.fieldRelativeMode) robot.turret.fieldTargetAngle = override
-            else robot.turret.targetAngle = override
+        positionOverride?.let {
+            if (robot.turret.fieldRelativeMode) robot.turret.fieldTargetAngle = it
+            else robot.turret.targetAngle = it
         }
     }
 
-    override fun close() {
-        autoAim.close()
-    }
+    override fun close() { autoAim.close() }
 
-    // ------------------------------------------------------------------
-    // Internal pipeline
-    // ------------------------------------------------------------------
+    // ── Internal ─────────────────────────────────────────────────────
 
     private fun updateVision() {
         val visionResult = visionTracker?.read()
         autoAim.update(robot.io.position(), robot.io.velocity(), robot.io.turretPosition(), visionResult)
-
         val fusedPose = autoAim.fusedPose
         targetDistance = hypot(goalPosition.x - fusedPose.v.x, goalPosition.y - fusedPose.v.y)
     }
@@ -197,22 +166,15 @@ class NativeAutoAim(
         val turret  = robot.turret
         val fusedPose = autoAim.fusedPose
         val now = robot.io.time()
-
         val nBalls = robot.beamBreak.ballCount
 
-        // ── Burst sequencing: detect ball exits ──────────────────────────
+        // ── Burst sequencing: detect ball exits ──────────────────────
         if (burstActive) {
-            val ballsFiredSoFar = burstStartBallCount - nBalls
-            if (ballsFiredSoFar > burstShotsFired) {
-                // A ball just exited
-                burstShotsFired = ballsFiredSoFar
+            val fired = burstStartBallCount - nBalls
+            if (fired > burstShotsFired) {
+                burstShotsFired = fired
                 lastBallExitTime = now
-                // Immediately start transferring the next ball if any remain
-                if (burstShotsFired < burstTotalShots && nBalls > 0) {
-                    robot.intakeTransfer.state = IntakeTransfer.State.TRANSFERRING
-                }
             }
-            // Burst complete
             if (burstShotsFired >= burstTotalShots || nBalls == 0) {
                 burstActive = false
                 burstShotsFired = 0
@@ -220,11 +182,7 @@ class NativeAutoAim(
             }
         }
 
-        // ── Compute t_remaining ──────────────────────────────────────────
-        // Time until the next ball can physically exit the shooter.
-        //   Not in burst: transferDelay (ball needs full transfer to reach flywheel)
-        //   In burst, first ball not yet fired: transferDelay (same)
-        //   In burst, after a ball exited: transferDelay - elapsed since exit
+        // ── t_remaining ──────────────────────────────────────────────
         val tRemaining: Float = if (burstActive && lastBallExitTime != null) {
             val elapsed = (now - lastBallExitTime!!).inWholeMilliseconds / 1000.0
             (AimConfig.transferDelay - elapsed).coerceAtLeast(0.0).toFloat()
@@ -232,110 +190,152 @@ class NativeAutoAim(
             AimConfig.transferDelay.toFloat()
         }
 
-        // How many balls remain to plan for
-        val remainingBalls = if (burstActive) {
+        val remainingBalls = if (burstActive)
             (burstTotalShots - burstShotsFired).coerceIn(1, nBalls)
-        } else {
-            nBalls.coerceAtLeast(1)
-        }
+        else nBalls.coerceAtLeast(1)
 
-        // Robot velocity in field frame
         val odoVel = Vector2d(robot.io.velocity().v)
         val vel = odoVel.rotate(fusedPose.rot - robot.io.position().rot)
 
         val tX = fusedPose.v.x.toFloat()
         val tY = fusedPose.v.y.toFloat()
         val tZ = turretPos.z.toFloat()
-
         val goal = FieldLandmarks.goalPosition3d(blue, AimConfig.goalHeight)
-        val gX = goal.x.toFloat()
-        val gY = goal.y.toFloat()
-        val gZ = goal.z.toFloat()
-
-        val robotVx = vel.x.toFloat()
-        val robotVy = vel.y.toFloat()
-
+        val gX = goal.x.toFloat(); val gY = goal.y.toFloat(); val gZ = goal.z.toFloat()
         val curTheta = (turret.pos + fusedPose.rot).toFloat()
         val curPhi   = shooter.computedHoodAngle.toFloat()
         val curOmega = robot.io.flywheelVelocity().toFloat()
 
-        // ── Launch-zone: compute effective t_remaining ────────────────────
-        // When outside a defined zone, inflate t_remaining so urgency drops
-        // to ~0 and the solver optimizes purely for inter-shot robustness.
-        // The turret slews toward s1 naturally over the approach time.
-        val zoneNx = AimConfig.launchZoneNx
-        val zoneNy = AimConfig.launchZoneNy
-        val zoneD  = AimConfig.launchZoneD
-        val zoneDefined = zoneNx != 0.0 || zoneNy != 0.0
+        val robotVx = vel.x.toFloat()
+        val robotVy = vel.y.toFloat()
 
-        val zoneZ0 = if (zoneDefined) zoneNx * fusedPose.v.x + zoneNy * fusedPose.v.y - zoneD
-                     else Double.POSITIVE_INFINITY
-        val inZone = zoneZ0 >= 0.0
+        // ── Time to zone estimate ─────────────────────────────────────
+        val timeToZone = run {
+            if (robot.intakeCoordinator.inShootingZone) return@run 0.0
 
-        val effectiveTRemaining: Float = if (zoneDefined && !inZone && !burstActive) {
-            // Outside the zone: estimate time until zone entry, add transfer delay.
-            // With high t_remaining, w_urgency → 0 so J_0 doesn't matter.
-            val nDotV = zoneNx * vel.x + zoneNy * vel.y
-            val tUntilZone = if (nDotV > 1e-3) (-zoneZ0 / nDotV).coerceAtLeast(0.0)
-                             else AimConfig.prepositionTAvailable
-            (tUntilZone + AimConfig.transferDelay).toFloat()
-        } else {
-            tRemaining
+            val robotPos = Vector2d(fusedPose.v.x, fusedPose.v.y)
+            val speed = hypot(vel.x, vel.y)
+
+            var bestTime = Double.MAX_VALUE
+            for (zone in listOf(goalZone, farZone)) {
+                val closest = closestPointOnConvexPolygon(zone, robotPos)
+                val dx = closest.x - robotPos.x
+                val dy = closest.y - robotPos.y
+                val dist = hypot(dx, dy)
+
+                if (dist < 1e-3) {
+                    bestTime = 0.0
+                    break
+                }
+                if (speed < 1e-3) continue
+                val approachSpeed = (vel.x * dx + vel.y * dy) / dist
+                if (approachSpeed <= 1e-3) continue
+                bestTime = minOf(bestTime, dist / approachSpeed)
+            }
+            bestTime
         }
+
+        // The solver's t_remaining: if outside the zone, push earliest shot
+        // to the zone-entry time so it solves from a valid shooting position.
+        val solverTRemaining = if (timeToZone > 0 && !burstActive)
+            tRemaining + timeToZone.toFloat()
+        else tRemaining
 
         var solved = false
         isRobustActive = false
-        isPrepositionActive = false
         secondaryShotState = null
         tertiaryShotState = null
+        allBallsFeasible = false
 
-        // ── Trajectory-aware robust solve (used everywhere) ──────────────
+        // ── Solve ────────────────────────────────────────────────────
         try {
-            val horizon = AimConfig.transferDelay * remainingBalls + AimConfig.predictionHorizon
-            val step = AimConfig.predictionStep.toFloat()
-            val nSteps = (horizon / step).toInt().coerceIn(2, 60)
+            val horizon = solverTRemaining + AimConfig.transferDelay * remainingBalls + AimConfig.predictionHorizon
+            val maxSteps = 60
+            val step = maxOf(AimConfig.predictionStep.toFloat(), (horizon / maxSteps).toFloat())
+            val nSteps = (horizon / step).toInt().coerceIn(2, maxSteps)
             val trajArray = FloatArray(nSteps * 6)
+
+            // Integrate trajectory with deceleration near shooting zones.
+            // When the predicted position is within 0.5m of a zone, assume the
+            // driver brakes — this prevents the solver from picking backward
+            // solutions caused by high velocity near the goal.
+            var px = tX
+            var py = tY
+            var vx = robotVx
+            var vy = robotVy
+            var decelerating = robot.intakeCoordinator.inShootingZone
+
             for (i in 0 until nSteps) {
+                // Check proximity to zones before recording velocity
+                if (!decelerating) {
+                    val pos = Vector2d(px.toDouble(), py.toDouble())
+                    for (zone in listOf(goalZone, farZone)) {
+                        val closest = closestPointOnConvexPolygon(zone, pos)
+                        if (hypot(closest.x - pos.x, closest.y - pos.y) < AimConfig.decelZoneMargin) {
+                            decelerating = true
+                            break
+                        }
+                    }
+                }
+
                 val t = i * step
                 trajArray[i * 6 + 0] = t
-                trajArray[i * 6 + 1] = tX + robotVx * t
-                trajArray[i * 6 + 2] = tY + robotVy * t
+                trajArray[i * 6 + 1] = px
+                trajArray[i * 6 + 2] = py
                 trajArray[i * 6 + 3] = fusedPose.rot.toFloat()
-                trajArray[i * 6 + 4] = robotVx
-                trajArray[i * 6 + 5] = robotVy
+                trajArray[i * 6 + 4] = vx
+                trajArray[i * 6 + 5] = vy
+
+                // Advance position, then apply deceleration for the next step
+                if (i < nSteps - 1) {
+                    px += vx * step
+                    py += vy * step
+
+                    if (decelerating) {
+                        val speed = hypot(vx.toDouble(), vy.toDouble()).toFloat()
+                        if (speed > 0.01f) {
+                            val newSpeed = maxOf(0f, speed - AimConfig.decelRate * step)
+                            vx *= newSpeed / speed
+                            vy *= newSpeed / speed
+                        } else {
+                            vx = 0f; vy = 0f
+                        }
+                    }
+                }
             }
 
             val r = bridge.robust3ShotPlan(
-                trajArray, nSteps,
-                tZ,
+                trajArray, nSteps, tZ,
                 gX, gY, gZ,
                 curTheta, curPhi, curOmega,
                 remainingBalls,
-                effectiveTRemaining,
+                solverTRemaining,
                 AimConfig.transferDelay.toFloat(),
                 AimConfig.dropFraction.toFloat(),
-                AimConfig.urgencyLambda.toFloat(),
                 weights, bounds, physConfig, omegaCoeffs
             )
 
             if (r[Robust3ShotPlanIdx.FEASIBLE] > 0.5f) {
-                // The solver found optimal flight times from future trajectory
-                // positions. Re-solve s1 from the CURRENT position using T1 so
-                // the turret theta is correct for right now (not for the future
-                // position). Phi and omega are nearly the same; theta changes
-                // significantly because it depends on the turret-to-goal angle.
-                val T1 = r[Robust3ShotPlanIdx.T1]
-                val nowShot = bridge.solve(
-                    tX, tY, tZ,
-                    gX, gY, gZ,
-                    robotVx, robotVy,
-                    T1,
-                    physConfig, omegaCoeffs
-                )
-                lastTheta = nowShot[TurretPlannerBridge.SolveIdx.THETA]
-                lastPhi   = nowShot[TurretPlannerBridge.SolveIdx.PHI]
-                lastOmega = nowShot[TurretPlannerBridge.SolveIdx.OMEGA]
+                // s1 from the solver is computed at the future trajectory point
+                // where the shot will actually happen. Use it directly as the
+                // actuator target so turret/hood arrive in advance.
+                // Clamp field-frame theta to the turret's reachable range.
+                // The solver uses [-π,π] theta bounds (full circle) but the
+                // physical turret can only reach ±90° from the robot heading.
+                var solverTheta = r[Robust3ShotPlanIdx.S1_THETA].toDouble()
+                val relAngle = wrapAngle(solverTheta - fusedPose.rot)
+                if (abs(relAngle) > TurretServoConfig.maxAngle) {
+                    solverTheta = wrapAngle(
+                        relAngle.coerceIn(TurretServoConfig.minAngle, TurretServoConfig.maxAngle)
+                                + fusedPose.rot
+                    )
+                }
+                lastTheta = solverTheta.toFloat()
+                lastPhi   = r[Robust3ShotPlanIdx.S1_PHI]
+                lastOmega = r[Robust3ShotPlanIdx.S1_OMEGA]
+                lastT1    = r[Robust3ShotPlanIdx.T1]
                 solved = true
+                allBallsFeasible = true
 
                 if (remainingBalls >= 2) {
                     isRobustActive = true
@@ -353,9 +353,7 @@ class NativeAutoAim(
                     )
                 }
             }
-        } catch (_: Exception) {
-            // leaves last* untouched; readyToShoot set false below
-        }
+        } catch (_: Exception) { }
 
         if (!solved) {
             readyToShoot = false
@@ -371,27 +369,65 @@ class NativeAutoAim(
             vExit = lastOmega.toDouble() * flywheelRadius * AimConfig.launchEfficiency,
         )
 
+        // ── Actuator targeting with look-ahead ───────────────────────
+        // During a burst, once a ball is committed to the transfer the hood
+        // angle and turret for that ball are locked in (only flywheel speed
+        // matters at exit). Start moving hood/turret toward the NEXT shot's
+        // parameters immediately so the servos arrive in time.
+        val nextShotState = secondaryShotState  // s2 is always the next shot after s1
+
+        val targetTheta: Double
+        val targetPhi: Double
+        val targetOmega: Double
+
+        if (burstActive && nextShotState != null && tRemaining <= 0.05) {
+            // Ball in transit — keep flywheel on s1's omega (it's what the
+            // current ball needs), but slew hood toward s2 now. Theta stays
+            // on s1 to avoid overcorrection from the future-position angle.
+            targetTheta = lastTheta.toDouble()
+            targetPhi   = nextShotState.phi
+            targetOmega = lastOmega.toDouble()  // hold current shot's flywheel
+        } else {
+            targetTheta = lastTheta.toDouble()
+            targetPhi   = lastPhi.toDouble()
+            targetOmega = lastOmega.toDouble()
+        }
+
         if (aimTurret) {
             turret.fieldRelativeMode = true
-            turret.fieldTargetAngle = lastTheta.toDouble()
+            turret.fieldTargetAngle = targetTheta
         }
 
         if (robot.aimFlywheel) {
-            shooter.hoodAngle = lastPhi.toDouble()
-            shooter.flywheelTarget = lastOmega.toDouble()
+            shooter.hoodAngle = targetPhi
+            // Only spin up the flywheel when close enough to a launch zone
+            shooter.flywheelTarget = if (timeToZone <= AimConfig.spinupLeadTime || burstActive)
+                targetOmega else 0.0
         }
 
-        if (solved) {
-            val thetaErr = abs(wrapAngle(turret.pos + fusedPose.rot - lastTheta))
-            val phiErr   = abs(shooter.computedHoodAngle - lastPhi)
-            val omegaErr = abs(robot.io.flywheelVelocity() - lastOmega)
-            readyToShoot = thetaErr < turretTol && phiErr < hoodTol && omegaErr < omegaTol
-        } else {
-            readyToShoot = false
+        // readyToShoot: forward-simulate the shot from the current position
+        // with the current actuator state and check if it hits the goal.
+        val inTolerance = run {
+            val actualTheta = (turret.pos + fusedPose.rot).toFloat()
+            val actualPhi   = shooter.computedHoodAngle.toFloat()
+            val actualOmega = robot.io.flywheelVelocity().toFloat()
+            val actualVexit = (actualOmega * flywheelRadius * AimConfig.launchEfficiency).toFloat()
+
+            val missDistance = bridge.shotError(
+                tX, tY, tZ,
+                gX, gY, gZ,
+                robotVx, robotVy,
+                actualTheta, actualPhi, actualVexit, actualOmega,
+                lastT1,
+                physConfig
+            )
+            missDistance < AimConfig.shotTolerance && timeToZone <= 0
         }
 
-        // ── Fire / burst trigger ─────────────────────────────────────────
-        if (shotRequested && readyToShoot) {
+        // ── Fire: only in zone, only when solver confirms all balls feasible ──
+        // During a burst with look-ahead active, we're already committed so
+        // readyToShoot stays true even if we go out of tolerance
+        if (shotRequested && (burstActive || inTolerance) && allBallsFeasible) {
             if (!burstActive) {
                 burstActive = true
                 burstShotsFired = 0
@@ -399,8 +435,10 @@ class NativeAutoAim(
                 burstTotalShots = nBalls
                 lastBallExitTime = null
             }
-            shotRequested = false
-            robot.intakeTransfer.state = IntakeTransfer.State.TRANSFERRING
+            readyToShoot = true
+        } else {
+            readyToShoot = false
+            burstActive = false
         }
     }
 

--- a/TeamCode/src/main/java/sigmacorns/logic/NativeAutoAim.kt
+++ b/TeamCode/src/main/java/sigmacorns/logic/NativeAutoAim.kt
@@ -41,6 +41,10 @@ class NativeAutoAim(
     private val robot: Robot,
     private val blue: Boolean,
 ) : AutoAim {
+    companion object {
+        private val Double.f get() = "%.3f".format(this)
+        private val Float.f  get() = "%.3f".format(this)
+    }
 
     override lateinit var autoAim: GTSAMEstimator
         private set
@@ -70,6 +74,8 @@ class NativeAutoAim(
     override var isRobustActive: Boolean = false
         private set
 
+    private var logFrame = 0
+
     // ── Burst sequencing ─────────────────────────────────────────────
     private var burstActive = false
     private var burstStartBallCount = 0
@@ -79,6 +85,13 @@ class NativeAutoAim(
 
     /** True when the last solve was feasible for all balls (burst is safe to start). */
     private var allBallsFeasible = false
+
+    override var plannedShot: PlannedShot? = null
+        set(value) {
+            field = value
+            plannedShotSetTime = if (value != null) robot.io.time() else null
+        }
+    private var plannedShotSetTime: kotlin.time.Duration? = null
 
     // ── Zones (mirrored for alliance) ────────────────────────────────
     private lateinit var goalZone: List<Vector2d>
@@ -163,6 +176,7 @@ class NativeAutoAim(
     }
 
     private fun setShooterInputs(aimTurret: Boolean) {
+        val shouldLog = (logFrame++ % 25 == 0) && false
         val shooter = robot.shooter
         val turret  = robot.turret
         val fusedPose = autoAim.fusedPose
@@ -211,8 +225,11 @@ class NativeAutoAim(
         val robotVy = vel.y.toFloat()
 
         // ── Time to zone estimate ─────────────────────────────────────
+        // Skipped when a planned shot is set — timeUntilPlannedShot carries the
+        // exact countdown instead, so the velocity-projection scan is redundant.
         val timeToZone = run {
             if (robot.intakeCoordinator.inShootingZone) return@run 0.0
+            if (plannedShot != null) return@run Double.MAX_VALUE
 
             val robotPos = Vector2d(fusedPose.v.x, fusedPose.v.y)
             val speed = hypot(vel.x, vel.y)
@@ -236,11 +253,38 @@ class NativeAutoAim(
             bestTime
         }
 
-        // The solver's t_remaining: if outside the zone, push earliest shot
-        // to the zone-entry time so it solves from a valid shooting position.
-        val solverTRemaining = if (timeToZone > 0 && !burstActive)
-            tRemaining + timeToZone.toFloat()
-        else tRemaining
+        // Time until the robot reaches the planned shot position, counting down from
+        // when the plan was set.  Used for both prespin gating and solverTRemaining.
+        val timeUntilPlannedShot: Double? = run {
+            val ps = plannedShot ?: return@run null
+            val setTime = plannedShotSetTime ?: return@run null
+            val elapsed = (now - setTime).inWholeMilliseconds / 1000.0
+            (ps.timeToArrival.inWholeMilliseconds / 1000.0 - elapsed).coerceAtLeast(0.0)
+        }
+
+        // The solver's t_remaining: prefer the exact planned arrival time so the
+        // C++ solver pre-aims for the correct position; fall back to zone estimate.
+        val solverTRemaining = when {
+            burstActive -> tRemaining
+            timeUntilPlannedShot != null -> (tRemaining + timeUntilPlannedShot).toFloat()
+            timeToZone > 0 -> tRemaining + timeToZone.toFloat()
+            else -> tRemaining
+        }
+
+        if (shouldLog) {
+            val ps = plannedShot
+            if (ps != null) {
+                val horizon = solverTRemaining + AimConfig.transferDelay * remainingBalls + AimConfig.predictionHorizon
+                println("[NativeAutoAim] plannedShot: eta=${ps.timeToArrival.inWholeMilliseconds}ms" +
+                        " remaining=${timeUntilPlannedShot?.let { "%.2fs".format(it) } ?: "null"}" +
+                        " solverT=${"%.3f".format(solverTRemaining)}s horizon=${"%.3f".format(horizon)}s" +
+                        " balls=$remainingBalls" +
+                        " pos=(${ps.state.pos.v.x.f},${ps.state.pos.v.y.f})" +
+                        " vel=(${ps.state.vel.v.x.f},${ps.state.vel.v.y.f})")
+            } else {
+                println("[NativeAutoAim] plannedShot=null timeToZone=${timeToZone.f}s solverT=${solverTRemaining.f}s")
+            }
+        }
 
         var solved = false
         isRobustActive = false
@@ -250,56 +294,85 @@ class NativeAutoAim(
 
         // ── Solve ────────────────────────────────────────────────────
         try {
-            val horizon = solverTRemaining + AimConfig.transferDelay * remainingBalls + AimConfig.predictionHorizon
-            val maxSteps = 60
-            val step = maxOf(AimConfig.predictionStep.toFloat(), (horizon / maxSteps).toFloat())
-            val nSteps = (horizon / step).toInt().coerceIn(2, maxSteps)
-            val trajArray = FloatArray(nSteps * 6)
+            val ps = plannedShot
+            val nSteps: Int
+            val trajArray: FloatArray
 
-            // Integrate trajectory with deceleration near shooting zones.
-            // When the predicted position is within 0.5m of a zone, assume the
-            // driver brakes — this prevents the solver from picking backward
-            // solutions caused by high velocity near the goal.
-            var px = tX
-            var py = tY
-            var vx = robotVx
-            var vy = robotVy
-            var decelerating = robot.intakeCoordinator.inShootingZone
+            if (ps != null && !burstActive) {
+                // Linearly interpolate from current state to planned state over
+                // [0, solverTRemaining], then hold the planned state for the rest
+                // of the horizon so the solver has room to plan the full burst.
+                val horizon = (solverTRemaining + AimConfig.transferDelay * remainingBalls + AimConfig.predictionHorizon).toFloat()
+                nSteps = 20
+                trajArray = FloatArray(nSteps * 6)
+                val arriveT = if (solverTRemaining > 1e-6f) solverTRemaining else 1e-6f
+                val shotX = ps.state.pos.v.x.toFloat()
+                val shotY = ps.state.pos.v.y.toFloat()
+                val shotVx = ps.state.vel.v.x.toFloat()
+                val shotVy = ps.state.vel.v.y.toFloat()
+                val heading = fusedPose.rot.toFloat()
+                for (i in 0 until nSteps) {
+                    val t = (i.toFloat() / (nSteps - 1)) * horizon
+                    val frac = (t / arriveT).coerceIn(0f, 1f)
+                    trajArray[i * 6 + 0] = t
+                    trajArray[i * 6 + 1] = tX + frac * (shotX - tX)
+                    trajArray[i * 6 + 2] = tY + frac * (shotY - tY)
+                    trajArray[i * 6 + 3] = heading
+                    trajArray[i * 6 + 4] = robotVx + frac * (shotVx - robotVx)
+                    trajArray[i * 6 + 5] = robotVy + frac * (shotVy - robotVy)
+                }
+            } else {
+                val horizon = solverTRemaining + AimConfig.transferDelay * remainingBalls + AimConfig.predictionHorizon
+                val maxSteps = 60
+                val step = maxOf(AimConfig.predictionStep.toFloat(), (horizon / maxSteps).toFloat())
+                nSteps = (horizon / step).toInt().coerceIn(2, maxSteps)
+                trajArray = FloatArray(nSteps * 6)
 
-            for (i in 0 until nSteps) {
-                // Check proximity to zones before recording velocity
-                if (!decelerating) {
-                    val pos = Vector2d(px.toDouble(), py.toDouble())
-                    for (zone in listOf(goalZone, farZone)) {
-                        val closest = closestPointOnConvexPolygon(zone, pos)
-                        if (hypot(closest.x - pos.x, closest.y - pos.y) < AimConfig.decelZoneMargin) {
-                            decelerating = true
-                            break
+                // Integrate trajectory with deceleration near shooting zones.
+                // When the predicted position is within 0.5m of a zone, assume the
+                // driver brakes — this prevents the solver from picking backward
+                // solutions caused by high velocity near the goal.
+                var px = tX
+                var py = tY
+                var vx = robotVx
+                var vy = robotVy
+                var decelerating = robot.intakeCoordinator.inShootingZone
+
+                for (i in 0 until nSteps) {
+                    // Check proximity to zones before recording velocity
+                    if (!decelerating) {
+                        val pos = Vector2d(px.toDouble(), py.toDouble())
+                        for (zone in listOf(goalZone, farZone)) {
+                            val closest = closestPointOnConvexPolygon(zone, pos)
+                            if (hypot(closest.x - pos.x, closest.y - pos.y) < AimConfig.decelZoneMargin) {
+                                decelerating = true
+                                break
+                            }
                         }
                     }
-                }
 
-                val t = i * step
-                trajArray[i * 6 + 0] = t
-                trajArray[i * 6 + 1] = px
-                trajArray[i * 6 + 2] = py
-                trajArray[i * 6 + 3] = fusedPose.rot.toFloat()
-                trajArray[i * 6 + 4] = vx
-                trajArray[i * 6 + 5] = vy
+                    val t = i * step
+                    trajArray[i * 6 + 0] = t
+                    trajArray[i * 6 + 1] = px
+                    trajArray[i * 6 + 2] = py
+                    trajArray[i * 6 + 3] = fusedPose.rot.toFloat()
+                    trajArray[i * 6 + 4] = vx
+                    trajArray[i * 6 + 5] = vy
 
-                // Advance position, then apply deceleration for the next step
-                if (i < nSteps - 1) {
-                    px += vx * step
-                    py += vy * step
+                    // Advance position, then apply deceleration for the next step
+                    if (i < nSteps - 1) {
+                        px += vx * step
+                        py += vy * step
 
-                    if (decelerating) {
-                        val speed = hypot(vx.toDouble(), vy.toDouble()).toFloat()
-                        if (speed > 0.01f) {
-                            val newSpeed = maxOf(0f, speed - AimConfig.decelRate * step)
-                            vx *= newSpeed / speed
-                            vy *= newSpeed / speed
-                        } else {
-                            vx = 0f; vy = 0f
+                        if (decelerating) {
+                            val speed = hypot(vx.toDouble(), vy.toDouble()).toFloat()
+                            if (speed > 0.01f) {
+                                val newSpeed = maxOf(0f, speed - AimConfig.decelRate * step)
+                                vx *= newSpeed / speed
+                                vy *= newSpeed / speed
+                            } else {
+                                vx = 0f; vy = 0f
+                            }
                         }
                     }
                 }
@@ -354,7 +427,15 @@ class NativeAutoAim(
                     )
                 }
             }
-        } catch (_: Exception) { }
+        } catch (e: Exception) {
+            if (shouldLog) println("[NativeAutoAim] " + "solver threw: $e")
+        }
+
+        if (shouldLog) {
+            println("[NativeAutoAim] " + "solve: solved=$solved feasible=$allBallsFeasible" +
+                    " balls=$nBalls burst=$burstActive" +
+                    " shotReq=$shotRequested inZone=${robot.intakeCoordinator.inShootingZone}")
+        }
 
         if (!solved) {
             readyToShoot = false
@@ -399,9 +480,10 @@ class NativeAutoAim(
             turret.fieldTargetAngle = targetTheta
         }
 
-        val prespin = timeToZone <= AimConfig.spinupLeadTime &&
-                nBalls>0 &&
-                robot.intakeTransfer.state != IntakeTransfer.State.INTAKING
+        val prespin = nBalls > 0 &&
+                robot.intakeTransfer.state != IntakeTransfer.State.INTAKING &&
+                ((timeUntilPlannedShot != null && timeUntilPlannedShot <= AimConfig.spinupLeadTime)
+                        || timeToZone <= AimConfig.spinupLeadTime)
 
         if (robot.aimFlywheel) {
             shooter.hoodAngle = targetPhi
@@ -426,7 +508,15 @@ class NativeAutoAim(
                 lastT1,
                 physConfig
             )
-            missDistance < AimConfig.shotTolerance && timeToZone <= 0
+            val miss = missDistance < AimConfig.shotTolerance
+            val inZone = timeToZone <= 0 || timeUntilPlannedShot?.let { it <= 0.0 } == true
+            if (shouldLog) {
+                println("[NativeAutoAim] " + "inTolerance: missDistance=${"%.3f".format(missDistance)} miss=$miss inZone=$inZone" +
+                        " timeToZone=${timeToZone.f} untilPlanned=${timeUntilPlannedShot?.let { "%.2f".format(it) } ?: "null"}" +
+                        " actualOmega=${"%.1f".format(actualOmega)} targetOmega=${"%.1f".format(targetOmega)}" +
+                        " prespin=$prespin")
+            }
+            miss && inZone
         }
 
         // ── Fire: only in zone, only when solver confirms all balls feasible ──
@@ -439,6 +529,7 @@ class NativeAutoAim(
                 burstStartBallCount = nBalls
                 burstTotalShots = nBalls
                 lastBallExitTime = null
+                plannedShot = null  // plan consumed — burst is now executing
             }
             readyToShoot = true
         } else {

--- a/TeamCode/src/main/java/sigmacorns/logic/PlannedShot.kt
+++ b/TeamCode/src/main/java/sigmacorns/logic/PlannedShot.kt
@@ -1,0 +1,20 @@
+package sigmacorns.logic
+
+import sigmacorns.sim.MecanumState
+import kotlin.time.Duration
+
+/**
+ * A pre-planned shot target provided by an autonomous routine.
+ *
+ * When set on [sigmacorns.control.aim.AutoAim], [sigmacorns.logic.NativeAutoAim] uses
+ * [timeToArrival] to:
+ * - Prespin the flywheel as soon as [timeToArrival] drops within [AimConfig.spinupLeadTime]
+ *   (rather than relying on the coarse zone-proximity estimate)
+ * - Pass the exact remaining time to the C++ solver as [solverTRemaining] so it pre-aims
+ *   hood and turret for the shot at [state]
+ *
+ * @param state         the [MecanumState] (position + velocity) the robot will occupy when it shoots.
+ * @param timeToArrival estimated time from the moment this plan is handed to the auto-aim until
+ *                      the robot reaches [state].
+ */
+data class PlannedShot(val state: MecanumState, val timeToArrival: Duration)

--- a/TeamCode/src/main/java/sigmacorns/opmode/AutoTeleOp.kt
+++ b/TeamCode/src/main/java/sigmacorns/opmode/AutoTeleOp.kt
@@ -2,6 +2,7 @@ package sigmacorns.opmode
 
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp
 import sigmacorns.Robot
+import sigmacorns.logic.AutomationManager
 import sigmacorns.math.Pose2d
 import sigmacorns.subsystem.IntakeTransfer
 import sigmacorns.subsystem.ShooterConfig
@@ -17,49 +18,28 @@ import kotlin.math.max
  *   Right stick X       - Rotate
  *   D-pad up/down       - Speed mode toggle (full / precision)
  *   X                    - Toggle field-centric drive
+ *   Y                    - Toggle auto shoot
  *
  *   Left trigger         - Hold to intake balls
  *   B                    - Hold to reverse intake (spit balls out)
- *   Right trigger        - Hold to shoot (flywheel + transfer)
- *   Left bumper          - Hold to spin up flywheel (without shooting)
- *
- * GAMEPAD 2 (Operator - all subsystem controls):
- *   Left trigger         - Hold to intake balls
- *   B                    - Hold to reverse intake (spit balls out)
- *   Right trigger        - Hold to shoot (flywheel + transfer)
- *   Left bumper          - Hold to spin up flywheel (without shooting)
- *   A                    - Toggle auto-aim on/off
- *   Right stick X        - Manual turret override (disables auto-aim while held)
- *   Right stick Y        - Manual hood angle override
- *   X                    - Toggle shoot-while-move
- *   Y                    - Toggle auto-shoot (zone-based)
- *   D-pad up             - Toggle hood auto-adjust
- *   D-pad left           - Decrease flywheel target speed (-25 rad/s)
- *   D-pad right          - Increase flywheel target speed (+25 rad/s)
  */
-@TeleOp(name = "Main TeleOp", group = "Competition")
-class   MainTeleOp : SigmaOpMode() {
-
+@TeleOp(name = "Auto TeleOp", group = "Competition")
+class AutoTeleOp : SigmaOpMode() {
     override fun runOpMode() {
         val robot = Robot(io, blue = false, useNativeAim = true)
         robotRef = robot
         robot.init(Pose2d(), apriltagTracking = !SIM)
         robot.startApriltag()
 
+        val automationManager = AutomationManager(robot)
+
         // State
-        var autoAimEnabled = true
-        var flywheelTargetSpeed = 400.0
-        val flywheelSpeedStep = 25.0
+        robot.intakeCoordinator.autoShootEnabled = true
+        robot.aimTurret = true
+        robot.aimFlywheel = true
 
-        // Toggle debounce flags (GP1)
         var lastX1 = false
-
-        // Toggle debounce flags (GP2)
-        var lastA2 = false
         var lastY2 = false
-        var lastDpadUp2 = false
-        var lastDpadLeft2 = false
-        var lastDpadRight2 = false
 
         telemetry.addLine("Main TeleOp initialized. Waiting for start...")
         telemetry.update()
@@ -76,23 +56,14 @@ class   MainTeleOp : SigmaOpMode() {
             if (gamepad1.x && !lastX1) robot.drive.fieldCentric = !robot.drive.fieldCentric
             lastX1 = gamepad1.x
 
-            robot.drive.fieldCentricHeading = robot.aim.autoAim.fusedPose.rot - 0.5*PI
-            robot.drive.update(gamepad1, io)
-
-            // ============================================================
-            // GAMEPAD 2: Operator (ALL subsystem controls)
-            // ============================================================
-
-            // --- Flywheel speed adjustment (D-pad left/right) ---
-            if (gamepad2.dpad_left && !lastDpadLeft2) {
-                flywheelTargetSpeed = (flywheelTargetSpeed - flywheelSpeedStep).coerceAtLeast(0.0)
+            if(gamepad1.right_bumper && !automationManager.hasControl) {
+                automationManager.shootFarZone()
             }
-            lastDpadLeft2 = gamepad2.dpad_left
 
-            if (gamepad2.dpad_right && !lastDpadRight2) {
-                flywheelTargetSpeed = (flywheelTargetSpeed + flywheelSpeedStep).coerceAtMost(628.0)
+            if(!automationManager.update(gamepad1)) {
+                robot.drive.fieldCentricHeading = robot.aim.autoAim.fusedPose.rot - 0.5*PI
+                robot.drive.update(gamepad1, io)
             }
-            lastDpadRight2 = gamepad2.dpad_right
 
             // --- Intake: hold left trigger ---
             if ( (max(gamepad2.left_trigger,gamepad1.left_trigger) > 0.1 && max(gamepad2.right_trigger,gamepad1.right_trigger) <= 0.1) ) {
@@ -111,76 +82,11 @@ class   MainTeleOp : SigmaOpMode() {
                 robot.intakeTransfer.state = IntakeTransfer.State.IDLE
             }
 
-            // --- Toggle: Auto-aim (A button) ---
-            if (gamepad2.a && !lastA2) {
-                autoAimEnabled = !autoAimEnabled
-            }
-            lastA2 = gamepad2.a
-
             // --- Toggle: Auto-shoot zones (Y button) ---
             if (gamepad2.y && !lastY2) {
-                robot.intakeCoordinator.autoShootEnabled =
-                    !robot.intakeCoordinator.autoShootEnabled
+                robot.intakeCoordinator.autoShootEnabled = !robot.intakeCoordinator.autoShootEnabled
             }
             lastY2 = gamepad2.y
-
-            // --- Toggle: Hood auto-adjust (D-pad up) ---
-            if (gamepad2.dpad_up && !lastDpadUp2) {
-                robot.shooter.autoAdjust = !robot.shooter.autoAdjust
-            }
-            lastDpadUp2 = gamepad2.dpad_up
-
-            // --- Turret control ---
-            val manualTurretInput = gamepad2.right_stick_x.toDouble()
-            if (abs(manualTurretInput) > 0.05) {
-                // Manual override: robot-relative turret control
-                robot.aimTurret = false
-                robot.turret.fieldRelativeMode = false
-                robot.turret.targetAngle += manualTurretInput * 2.0 * dt.inWholeMilliseconds / 1000.0
-                robot.turret.targetAngle = robot.turret.targetAngle.coerceIn(-PI, PI)
-            } else if (autoAimEnabled) {
-                robot.aimTurret = true
-            }
-
-            // --- Hood manual override (right stick Y) ---
-            val manualHoodInput = -gamepad2.right_stick_y.toDouble()
-            if (abs(manualHoodInput) > 0.05) {
-                robot.shooter.autoAdjust = false
-                robot.shooter.manualHoodAngle += manualHoodInput * Math.toRadians(30.0) * dt.inWholeMilliseconds / 1000.0
-                robot.shooter.manualHoodAngle = robot.shooter.manualHoodAngle.coerceIn(
-                    Math.toRadians(ShooterConfig.minAngleDeg),
-                    Math.toRadians(ShooterConfig.maxAngleDeg)
-                )
-            }
-
-//            robot.io.flywheel = if (gamepad2.right_trigger > 0.1) { 0.88 } else { 0.0 }
-
-            // --- Shooting (right trigger) or flywheel spin-up (left bumper) ---
-            if (max(gamepad2.right_trigger, gamepad1.right_trigger) > 0.1) {
-                // Shooting: spin flywheel + transfer (blocker delay handled by state machine)
-                if(autoAimEnabled) {
-                    robot.aimFlywheel = true
-                    robot.aim.shotRequested = true
-                } else {
-                    robot.shooter.flywheelTarget = flywheelTargetSpeed
-                    robot.aimFlywheel = false
-                    robot.intakeTransfer.state = IntakeTransfer.State.TRANSFERRING
-                }
-            } else if (gamepad2.left_bumper || gamepad1.left_bumper) {
-                // Spin-up only: flywheel on, blocker stays engaged
-                robot.shooter.flywheelTarget = flywheelTargetSpeed
-                robot.aimFlywheel = false
-                robot.aim.shotRequested = false
-                robot.intakeTransfer.state = IntakeTransfer.State.IDLE
-            } else {
-                // Idle: stop flywheel, only reset transfer (not intake/reverse)
-                robot.shooter.flywheelTarget = 0.0
-                robot.aimFlywheel = false
-                robot.aim.shotRequested = false
-                if (robot.intakeTransfer.state == IntakeTransfer.State.TRANSFERRING) {
-                    robot.intakeTransfer.state = IntakeTransfer.State.IDLE
-                }
-            }
 
             // ============================================================
             // Robot update
@@ -210,7 +116,6 @@ class   MainTeleOp : SigmaOpMode() {
             telemetry.addLine("")
             telemetry.addLine("=== VISION ===")
             telemetry.addData("Vision Target", robot.aim.autoAim.hasVisionTarget)
-            telemetry.addData("Auto-Aim", if (autoAimEnabled) "ON" else "OFF")
 
             telemetry.addLine("")
             telemetry.addLine("=== SHOOTER ===")

--- a/TeamCode/src/main/java/sigmacorns/opmode/AutoTeleOp.kt
+++ b/TeamCode/src/main/java/sigmacorns/opmode/AutoTeleOp.kt
@@ -40,6 +40,8 @@ class AutoTeleOp : SigmaOpMode() {
 
         var lastX1 = false
         var lastY2 = false
+        var lastRB1 = false
+        var lastLB1 = false
 
         telemetry.addLine("Main TeleOp initialized. Waiting for start...")
         telemetry.update()
@@ -56,9 +58,13 @@ class AutoTeleOp : SigmaOpMode() {
             if (gamepad1.x && !lastX1) robot.drive.fieldCentric = !robot.drive.fieldCentric
             lastX1 = gamepad1.x
 
-            if(gamepad1.right_bumper && !automationManager.hasControl) {
+            if(gamepad1.right_bumper && !lastRB1) {
                 automationManager.shootFarZone()
+            } else if(gamepad1.left_bumper && !lastLB1) {
+                automationManager.shootGoalZone()
             }
+            lastRB1 = gamepad1.right_bumper
+            lastLB1 = gamepad1.left_bumper
 
             if(!automationManager.update(gamepad1)) {
                 robot.drive.fieldCentricHeading = robot.aim.autoAim.fusedPose.rot - 0.5*PI

--- a/TeamCode/src/main/java/sigmacorns/opmode/MainTeleOp.kt
+++ b/TeamCode/src/main/java/sigmacorns/opmode/MainTeleOp.kt
@@ -21,17 +21,18 @@ import kotlin.math.max
  *   Left trigger         - Hold to intake balls
  *   B                    - Hold to reverse intake (spit balls out)
  *   Right trigger        - Hold to shoot (flywheel + transfer)
- *   Left bumper          - Hold to spin up flywheel (without shooting)
  *
  * GAMEPAD 2 (Operator - all subsystem controls):
- *   Left trigger         - Hold to intake balls
+ *   Left stick           - Translate (mecanum drive, when GP2 drive enabled)
+ *   Right stick X        - Rotate (when GP2 drive enabled) / Manual turret override (when drive disabled)
+ *   X                    - Toggle GP2 mecanum drive on/off
+ *   Left trigger         - Hold to intake (only when GP2 drive enabled)
  *   B                    - Hold to reverse intake (spit balls out)
- *   Right trigger        - Hold to shoot (flywheel + transfer)
+ *   Right trigger        - Hold to shoot (only when GP2 drive enabled)
  *   Left bumper          - Hold to spin up flywheel (without shooting)
+ *   Right bumper         - Toggle flywheel always-on (0.4 power)
  *   A                    - Toggle auto-aim on/off
- *   Right stick X        - Manual turret override (disables auto-aim while held)
  *   Right stick Y        - Manual hood angle override
- *   X                    - Toggle shoot-while-move
  *   Y                    - Toggle auto-shoot (zone-based)
  *   D-pad up             - Toggle hood auto-adjust
  *   D-pad left           - Decrease flywheel target speed (-25 rad/s)
@@ -50,6 +51,8 @@ class   MainTeleOp : SigmaOpMode() {
         var autoAimEnabled = true
         var flywheelTargetSpeed = 400.0
         val flywheelSpeedStep = 25.0
+        var flywheelAlwaysOn = true
+        var gp2DriveEnabled = false
 
         // Toggle debounce flags (GP1)
         var lastX1 = false
@@ -57,9 +60,14 @@ class   MainTeleOp : SigmaOpMode() {
         // Toggle debounce flags (GP2)
         var lastA2 = false
         var lastY2 = false
+        var lastX2 = false
+        var lastRightBumper2 = false
         var lastDpadUp2 = false
         var lastDpadLeft2 = false
         var lastDpadRight2 = false
+
+        // Start in robot-centric mode
+        robot.drive.fieldCentric = false
 
         telemetry.addLine("Main TeleOp initialized. Waiting for start...")
         telemetry.update()
@@ -68,20 +76,37 @@ class   MainTeleOp : SigmaOpMode() {
 
         ioLoop { state, dt ->
             // ============================================================
-            // GAMEPAD 1: Driver (driving ONLY) + Debug/Tuning
+            // GAMEPAD 1: Driver (driving + intake/shoot)
             // ============================================================
 
-            // Drivetrain: left stick = translate, right stick x = rotate, dpad = speed mode
             // X button toggles field-centric mode
             if (gamepad1.x && !lastX1) robot.drive.fieldCentric = !robot.drive.fieldCentric
             lastX1 = gamepad1.x
 
             robot.drive.fieldCentricHeading = robot.aim.autoAim.fusedPose.rot - 0.5*PI
-            robot.drive.update(gamepad1, io)
+
+            // Drive from GP1 always active; GP2 drive only when enabled
+            if (gp2DriveEnabled) {
+                robot.drive.update(gamepad2, io)
+            } else {
+                robot.drive.update(gamepad1, io)
+            }
 
             // ============================================================
             // GAMEPAD 2: Operator (ALL subsystem controls)
             // ============================================================
+
+            // --- Toggle: GP2 mecanum drive (X button) ---
+            if (gamepad2.x && !lastX2) {
+                gp2DriveEnabled = !gp2DriveEnabled
+            }
+            lastX2 = gamepad2.x
+
+            // --- Toggle: Flywheel always-on (right bumper) ---
+            if (gamepad2.right_bumper && !lastRightBumper2) {
+                flywheelAlwaysOn = !flywheelAlwaysOn
+            }
+            lastRightBumper2 = gamepad2.right_bumper
 
             // --- Flywheel speed adjustment (D-pad left/right) ---
             if (gamepad2.dpad_left && !lastDpadLeft2) {
@@ -94,18 +119,22 @@ class   MainTeleOp : SigmaOpMode() {
             }
             lastDpadRight2 = gamepad2.dpad_right
 
-            // --- Intake: hold left trigger ---
-            if ( (max(gamepad2.left_trigger,gamepad1.left_trigger) > 0.1 && max(gamepad2.right_trigger,gamepad1.right_trigger) <= 0.1) ) {
+            // --- Intake: GP1 left trigger, or GP2 left trigger when GP2 drive active ---
+            val intakeTriggered = gamepad1.left_trigger > 0.1 ||
+                (gp2DriveEnabled && gamepad2.left_trigger > 0.1)
+            val shootTriggered = gamepad1.right_trigger > 0.1 ||
+                (gp2DriveEnabled && gamepad2.right_trigger > 0.1)
+            if (intakeTriggered && !shootTriggered) {
                 robot.intakeCoordinator.startIntake()
-            } else if (!gamepad2.b || !gamepad1.b) {
+            } else if (!gamepad1.b && !gamepad2.b) {
                 if (robot.intakeTransfer.state == IntakeTransfer.State.INTAKING ||
                     robot.intakeTransfer.state == IntakeTransfer.State.REVERSING) {
                     robot.intakeTransfer.state = IntakeTransfer.State.IDLE
                 }
             }
 
-            // --- Outtake: hold B to reverse intake ---
-            if (gamepad2.b || gamepad1.b) {
+            // --- Outtake: hold B (GP1 or GP2) ---
+            if (gamepad1.b || gamepad2.b) {
                 robot.intakeTransfer.state = IntakeTransfer.State.REVERSING
             } else if (robot.intakeTransfer.state == IntakeTransfer.State.REVERSING) {
                 robot.intakeTransfer.state = IntakeTransfer.State.IDLE
@@ -130,16 +159,17 @@ class   MainTeleOp : SigmaOpMode() {
             }
             lastDpadUp2 = gamepad2.dpad_up
 
-            // --- Turret control ---
-            val manualTurretInput = gamepad2.right_stick_x.toDouble()
-            if (abs(manualTurretInput) > 0.05) {
-                // Manual override: robot-relative turret control
-                robot.aimTurret = false
-                robot.turret.fieldRelativeMode = false
-                robot.turret.targetAngle += manualTurretInput * 2.0 * dt.inWholeMilliseconds / 1000.0
-                robot.turret.targetAngle = robot.turret.targetAngle.coerceIn(-PI, PI)
-            } else if (autoAimEnabled) {
-                robot.aimTurret = true
+            // --- Turret control (only when GP2 drive is disabled) ---
+            if (!gp2DriveEnabled) {
+                val manualTurretInput = gamepad2.right_stick_x.toDouble()
+                if (abs(manualTurretInput) > 0.05) {
+                    robot.aimTurret = false
+                    robot.turret.fieldRelativeMode = false
+                    robot.turret.targetAngle += manualTurretInput * 2.0 * dt.inWholeMilliseconds / 1000.0
+                    robot.turret.targetAngle = robot.turret.targetAngle.coerceIn(-PI, PI)
+                } else if (autoAimEnabled) {
+                    robot.aimTurret = true
+                }
             }
 
             // --- Hood manual override (right stick Y) ---
@@ -153,11 +183,8 @@ class   MainTeleOp : SigmaOpMode() {
                 )
             }
 
-//            robot.io.flywheel = if (gamepad2.right_trigger > 0.1) { 0.88 } else { 0.0 }
-
             // --- Shooting (right trigger) or flywheel spin-up (left bumper) ---
-            if (max(gamepad2.right_trigger, gamepad1.right_trigger) > 0.1) {
-                // Shooting: spin flywheel + transfer (blocker delay handled by state machine)
+            if (shootTriggered) {
                 if(autoAimEnabled) {
                     robot.aimFlywheel = true
                     robot.aim.shotRequested = true
@@ -166,19 +193,22 @@ class   MainTeleOp : SigmaOpMode() {
                     robot.aimFlywheel = false
                     robot.intakeTransfer.state = IntakeTransfer.State.TRANSFERRING
                 }
-            } else if (gamepad2.left_bumper || gamepad1.left_bumper) {
-                // Spin-up only: flywheel on, blocker stays engaged
+            } else if (gamepad2.left_bumper) {
+                // Spin-up only: flywheel on, no transfer
                 robot.shooter.flywheelTarget = flywheelTargetSpeed
                 robot.aimFlywheel = false
                 robot.aim.shotRequested = false
-                robot.intakeTransfer.state = IntakeTransfer.State.IDLE
             } else {
-                // Idle: stop flywheel, only reset transfer (not intake/reverse)
-                robot.shooter.flywheelTarget = 0.0
                 robot.aimFlywheel = false
                 robot.aim.shotRequested = false
                 if (robot.intakeTransfer.state == IntakeTransfer.State.TRANSFERRING) {
                     robot.intakeTransfer.state = IntakeTransfer.State.IDLE
+                }
+                // Flywheel always-on at 0.4 power when toggle is enabled
+                if (flywheelAlwaysOn) {
+                    robot.shooter.flywheelTarget = 0.4
+                } else {
+                    robot.shooter.flywheelTarget = 0.0
                 }
             }
 
@@ -242,6 +272,8 @@ class   MainTeleOp : SigmaOpMode() {
             telemetry.addData("Blocker", if (io.blocker == 0.0) "ENGAGED" else "DISENGAGED")
             telemetry.addData("Auto-Shoot", if (robot.intakeCoordinator.autoShootEnabled) "ON" else "OFF")
             telemetry.addData("In Shoot Zone", robot.intakeCoordinator.inShootingZone)
+            telemetry.addData("Flywheel Always-On", if (flywheelAlwaysOn) "ON" else "OFF")
+            telemetry.addData("GP2 Drive", if (gp2DriveEnabled) "ON" else "OFF")
             telemetry.addData("Speed Mode", if (robot.drive.getSpeedMultiplier() == 1.0) "FULL" else "PRECISION")
             telemetry.addData("Field-Centric", if (robot.drive.fieldCentric) "ON" else "OFF")
             telemetry.addData("Loop Time", "%d ms", dt.inWholeMilliseconds)

--- a/TeamCode/src/main/java/sigmacorns/opmode/MainTeleOp.kt
+++ b/TeamCode/src/main/java/sigmacorns/opmode/MainTeleOp.kt
@@ -46,6 +46,8 @@ class   MainTeleOp : SigmaOpMode() {
         robot.init(Pose2d(), apriltagTracking = !SIM)
         robot.startApriltag()
 
+        robot.intakeCoordinator.autoShootEnabled = true
+
         // State
         var autoAimEnabled = true
         var flywheelTargetSpeed = 400.0
@@ -172,7 +174,7 @@ class   MainTeleOp : SigmaOpMode() {
                 robot.aimFlywheel = false
                 robot.aim.shotRequested = false
                 robot.intakeTransfer.state = IntakeTransfer.State.IDLE
-            } else {
+            } else if(!robot.intakeCoordinator.autoShootEnabled) {
                 // Idle: stop flywheel, only reset transfer (not intake/reverse)
                 robot.shooter.flywheelTarget = 0.0
                 robot.aimFlywheel = false

--- a/TeamCode/src/main/java/sigmacorns/opmode/test/WaypointSquareTest.kt
+++ b/TeamCode/src/main/java/sigmacorns/opmode/test/WaypointSquareTest.kt
@@ -1,6 +1,7 @@
 package sigmacorns.opmode.test
 
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp
+import sigmacorns.Robot
 import sigmacorns.State
 import sigmacorns.constants.drivetrainParameters
 import sigmacorns.control.ltv.LTVClient
@@ -35,8 +36,6 @@ class WaypointSquareTest : SigmaOpMode() {
     private val INITIAL_T_REMAINING = 4.seconds
     // Minimum tRemaining passed to the solver (keeps N_eff >= 2 steps)
     private val MIN_T_REMAINING = 0.2.seconds
-    // Hard per-leg timeout — forces advance if the robot never converges
-    private val LEG_TIMEOUT = 10.seconds
 
     override fun runOpMode() {
         // 1m square corners, heading held at 0° throughout
@@ -47,77 +46,73 @@ class WaypointSquareTest : SigmaOpMode() {
             Pose2d(0.0, 0.0, 0.0),
         )
 
-        // Large Qf on velocity so zero-velocity arrival is well-penalised.
-        // No loadTrajectory() needed — solveWaypoint works from constructor alone.
-        val ltv = LTVClient(
-            parameters = drivetrainParameters,
-            qfDiag = doubleArrayOf(500.0, 500.0, 500.0, 10.0, 10.0, 10.0),
-        )
+        val robot = Robot(io,false)
 
-        ltv.use {
-            val state = State(io)
-            io.setPosition(Pose2d(0.0, 0.0, 0.0))
+        val state = State(io)
+        io.setPosition(Pose2d(0.0, 0.0, 0.0))
 
-            waitForStart()
-            io.setPosition(Pose2d(0.0, 0.0, 0.0))
+        waitForStart()
+        io.setPosition(Pose2d(0.0, 0.0, 0.0))
 
-            for ((idx, corner) in corners.withIndex()) {
-                val target      = MecanumState(vel = Pose2d(), pos = corner)
-                val legStart    = io.time()
-                val legDeadline = legStart + LEG_TIMEOUT
+        for ((idx, corner) in corners.withIndex()) {
+            val target      = MecanumState(vel = Pose2d(), pos = corner)
+            val legStart    = io.time()
 
-                // tRemaining for the first call — ETA not yet available
-                var tRemaining: Duration = INITIAL_T_REMAINING
+            // tRemaining for the first call — ETA not yet available
+            var tRemaining: Duration = INITIAL_T_REMAINING
 
-                while (opModeIsActive()) {
-                    state.update(io)
+            while (opModeIsActive()) {
+                state.update(io)
 
-                    var u = doubleArrayOf(0.0, 0.0, 0.0, 0.0)
-                    val solveNs = measureNanoTime {
-                        u = ltv.solveWaypoint(state.mecanumState, target, tRemaining, lqrRef = true)
-                    }
-
-                    // Update tRemaining from the solver's own forward-simulated ETA.
-                    // Clamp from below so the horizon never collapses to a single step.
-                    tRemaining = ltv.prevWaypointEta().coerceAtLeast(MIN_T_REMAINING)
-
-                    val voltage = io.voltage()
-                    io.driveFL = u[0] * 12.0 / voltage
-                    io.driveBL = u[1] * 12.0 / voltage
-                    io.driveBR = u[2] * 12.0 / voltage
-                    io.driveFR = u[3] * 12.0 / voltage
-
-                    val posErr = hypot(
-                        state.driveTrainPosition.v.x - corner.v.x,
-                        state.driveTrainPosition.v.y - corner.v.y,
-                    )
-                    val velMag = hypot(
-                        state.driveTrainVelocity.v.x,
-                        state.driveTrainVelocity.v.y,
-                    )
-
-                    telemetry.addData("leg", "${idx + 1} / ${corners.size}  →  (%.2f, %.2f)".format(corner.v.x, corner.v.y))
-                    telemetry.addData("pos", "(%.3f, %.3f, %.1f°)".format(
-                        state.driveTrainPosition.v.x,
-                        state.driveTrainPosition.v.y,
-                        Math.toDegrees(state.driveTrainPosition.rot),
-                    ))
-                    telemetry.addData("posErr",    "%.3f m".format(posErr))
-                    telemetry.addData("velMag",    "%.3f m/s".format(velMag))
-                    telemetry.addData("eta",       "%.2f s".format(tRemaining.toDouble(DurationUnit.SECONDS)))
-                    telemetry.addData("legElapsed","%.2f s".format((io.time() - legStart).toDouble(DurationUnit.SECONDS)))
-                    telemetry.addData("solveTime", "%.2f ms".format(solveNs / 1_000_000.0))
-                    telemetry.update()
-
-                    io.update()
-
-                    if (SIM) sleep(SIM_UPDATE_TIME.inWholeMilliseconds)
-
-                    val arrived  = posErr < POS_TOL && velMag < VEL_TOL
-                    val timedOut = io.time() > legDeadline
-                    if(idx == 3) continue
-                    if (arrived) break
+                var u = doubleArrayOf(0.0, 0.0, 0.0, 0.0)
+                val solveNs = measureNanoTime {
+                    u = robot.ltv.solveWaypoint(state.mecanumState, target, tRemaining, lqrRef = true)
                 }
+
+                // Update tRemaining from the solver's own forward-simulated ETA.
+                // Clamp from below so the horizon never collapses to a single step.
+                tRemaining = robot.ltv.prevWaypointEta().coerceAtLeast(MIN_T_REMAINING)
+
+                val voltage = io.voltage()
+                io.driveFL = u[0] * 12.0 / voltage
+                io.driveBL = u[1] * 12.0 / voltage
+                io.driveBR = u[2] * 12.0 / voltage
+                io.driveFR = u[3] * 12.0 / voltage
+
+                val posErr = hypot(
+                    state.driveTrainPosition.v.x - corner.v.x,
+                    state.driveTrainPosition.v.y - corner.v.y,
+                )
+                val velMag = hypot(
+                    state.driveTrainVelocity.v.x,
+                    state.driveTrainVelocity.v.y,
+                )
+
+                telemetry.addData("leg", "${idx + 1} / ${corners.size}  →  (%.2f, %.2f)".format(corner.v.x, corner.v.y))
+                telemetry.addData("pos", "(%.3f, %.3f, %.1f°)".format(
+                    state.driveTrainPosition.v.x,
+                    state.driveTrainPosition.v.y,
+                    Math.toDegrees(state.driveTrainPosition.rot),
+                ))
+                telemetry.addData("posErr",    "%.3f m".format(posErr))
+                telemetry.addData("velMag",    "%.3f m/s".format(velMag))
+                telemetry.addData("eta",       "%.2f s".format(tRemaining.toDouble(DurationUnit.SECONDS)))
+                telemetry.addData("legElapsed","%.2f s".format((io.time() - legStart).toDouble(DurationUnit.SECONDS)))
+                telemetry.addData("solveTime", "%.2f ms".format(solveNs / 1_000_000.0))
+                telemetry.update()
+
+                io.update()
+
+                if (SIM) sleep(SIM_UPDATE_TIME.inWholeMilliseconds)
+
+                val arrived  = posErr < POS_TOL && velMag < VEL_TOL
+                if(idx == 3) {
+                    if(arrived) {
+                        robot.ltv.holdPos(io, target.pos)
+                    }
+                    continue
+                }
+                if (arrived) break
             }
 
             // Stop all motors

--- a/TeamCode/src/main/jniLibs/arm64-v8a/libmecanum_ltv_jni.so
+++ b/TeamCode/src/main/jniLibs/arm64-v8a/libmecanum_ltv_jni.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d9b2b65b23bcef9a3348cc64006478fba24aa3d196aa4b67dace65c0faa5228a
-size 4309240
+oid sha256:c70cdf0638e5e426910de6f5ac967df1711df7cacfcc371663622c993dec7a95
+size 4376552

--- a/TeamCode/src/main/jniLibs/arm64-v8a/libturret_planner_jni.so
+++ b/TeamCode/src/main/jniLibs/arm64-v8a/libturret_planner_jni.so
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:315491d1b6dcbd55fcb979b550aba86be6e1df581db61a41f48c05bb79903e93
+size 321792

--- a/TeamCode/src/test/kotlin/sigmacorns/sim/viz/SimVizServer.kt
+++ b/TeamCode/src/test/kotlin/sigmacorns/sim/viz/SimVizServer.kt
@@ -268,21 +268,6 @@ class SimVizServer(
             }
         }
 
-        // 4. Preposition horizon-end.
-        if (r.aim.isPrepositionActive && target != null) {
-            val h = AimConfig.prepositionHorizon
-            val futurePivot = Vector3d(
-                pivot.x + vField.x * h,
-                pivot.y + vField.y * h,
-                pivot.z,
-            )
-            trajectories.add(trajToMap(
-                kind = "preposition",
-                dashed = false,
-                points = vizBallistics.sampleTrajectory(futurePivot, vField, target, stopZ),
-            ))
-        }
-
         val goal = mapOf(
             "x" to r.aim.goalPosition.x,
             "y" to r.aim.goalPosition.y,

--- a/TeamCode/src/test/kotlin/sigmacorns/sim/viz/SimVizServer.kt
+++ b/TeamCode/src/test/kotlin/sigmacorns/sim/viz/SimVizServer.kt
@@ -97,16 +97,16 @@ class SimVizServer(
      * objects. Call once per loop on the opmode thread before reading gamepads.
      */
     fun syncGamepads(gp1: Gamepad, gp2: Gamepad) {
-        applyToGamepad(gp1, gamepad1State)
-        applyToGamepad(gp2, gamepad2State)
+        applyToGamepad(gp1, gamepad1State, wasdState)
+        applyToGamepad(gp2, gamepad2State, null)
     }
 
-    private fun applyToGamepad(target: Gamepad, state: BrowserGamepadState) {
-        target.left_stick_x  = state.leftStickX
-        target.left_stick_y  = state.leftStickY
-        target.right_stick_x = state.rightStickX
+    private fun applyToGamepad(target: Gamepad, state: BrowserGamepadState, wasdState: WasdState?) {
+        target.left_stick_x  = state.leftStickX + (if(wasdState?.a == true) -1f else 0f) + if(wasdState?.d == true) 1f else 0f
+        target.left_stick_y  = state.leftStickY + (if(wasdState?.w == true) -1f else 0f) + if(wasdState?.s == true) 1f else 0f
+        target.right_stick_x = state.rightStickX + (if(wasdState?.q == true) -1f else 0f) + if(wasdState?.e == true) 1f else 0f
         target.right_stick_y = state.rightStickY
-        target.left_trigger  = state.leftTrigger
+        target.left_trigger  = state.leftTrigger + (if(wasdState?.q == true) -1f else 0f) + if(wasdState?.e == true) 1f else 0f
         target.right_trigger = state.rightTrigger
         target.a = state.a; target.b = state.b
         target.x = state.x; target.y = state.y
@@ -256,14 +256,24 @@ class SimVizServer(
             ))
         }
 
-        // 3. Robust secondary (dashed).
+        // 3. Robust secondary.
         if (r.aim.isRobustActive) {
             val s2 = r.aim.secondaryShotState
             if (s2 != null) {
                 trajectories.add(trajToMap(
                     kind = "secondary",
-                    dashed = true,
+                    dashed = false,
                     points = vizBallistics.sampleTrajectory(pivot, vField, s2, stopZ),
+                ))
+            }
+
+            // 4. Robust tertiary.
+            val s3 = r.aim.tertiaryShotState
+            if (s3 != null) {
+                trajectories.add(trajToMap(
+                    kind = "tertiary",
+                    dashed = false,
+                    points = vizBallistics.sampleTrajectory(pivot, vField, s3, stopZ),
                 ))
             }
         }

--- a/TeamCode/src/test/kotlin/sigmacorns/test/jolt/JoltTeleOpVisualizerTest.kt
+++ b/TeamCode/src/test/kotlin/sigmacorns/test/jolt/JoltTeleOpVisualizerTest.kt
@@ -2,6 +2,7 @@ package sigmacorns.test.jolt
 
 import org.junit.jupiter.api.Test
 import sigmacorns.io.JoltSimIO
+import sigmacorns.opmode.AutoTeleOp
 import sigmacorns.opmode.MainTeleOp
 import sigmacorns.opmode.SigmaOpMode
 import sigmacorns.sim.viz.SimVizServer
@@ -48,7 +49,7 @@ class JoltTeleOpVisualizerTest {
         Thread.sleep(500)
         println("Client connected. Starting MainTeleOp.")
 
-        val opmode = MainTeleOp()
+        val opmode = AutoTeleOp()
 
         // Launch the opmode; its ioLoop will step physics via io.update().
         val opmodeThread = Thread {

--- a/TeamCode/src/test/resources/web/scene.js
+++ b/TeamCode/src/test/resources/web/scene.js
@@ -451,27 +451,20 @@ scene.add(goalMarker);
 // don't allocate per frame. Dashed lines need computeLineDistances() after
 // each geometry update.
 const TRAJECTORY_KINDS = {
-    current:     { color: 0x00ccff, dashed: false },
-    target:      { color: 0xffaa00, dashed: false },
-    secondary:   { color: 0xffaa00, dashed: true  },
-    preposition: { color: 0xffaa00, dashed: false },
+    current:     { color: 0x2288ff, opacity: 0.9 },
+    target:      { color: 0x00dd44, opacity: 0.9 },
+    secondary:   { color: 0x00dd44, opacity: 0.45 },
+    tertiary:    { color: 0x00dd44, opacity: 0.25 },
+    preposition: { color: 0xffaa00, opacity: 0.6 },
 };
 
 const trajectoryLines = {};
 for (const [kind, cfg] of Object.entries(TRAJECTORY_KINDS)) {
-    const mat = cfg.dashed
-        ? new THREE.LineDashedMaterial({
-            color: cfg.color,
-            transparent: true,
-            opacity: 0.6,
-            dashSize: 0.05,
-            gapSize: 0.04,
-        })
-        : new THREE.LineBasicMaterial({
-            color: cfg.color,
-            transparent: true,
-            opacity: 0.6,
-        });
+    const mat = new THREE.LineBasicMaterial({
+        color: cfg.color,
+        transparent: true,
+        opacity: cfg.opacity,
+    });
     const geo = new THREE.BufferGeometry();
     const line = new THREE.Line(geo, mat);
     line.frustumCulled = false;
@@ -508,9 +501,6 @@ function updateShotViz(shotViz) {
             v3[i] = new THREE.Vector3(p[1], p[2], p[0]);
         }
         line.geometry.setFromPoints(v3);
-        if (line.material.isLineDashedMaterial) {
-            line.computeLineDistances();
-        }
         line.visible = true;
         seen.add(t.kind);
     }

--- a/deps/jolt_sim/src/jolt_world.cpp
+++ b/deps/jolt_sim/src/jolt_world.cpp
@@ -409,34 +409,29 @@ void JoltWorld::updateGates(float dt) {
     GoalInfo* goals[] = { &redGoal_, &blueGoal_ };
 
     for (auto* goal : goals) {
-        JPH::Vec3 gatePos = bodyInterface.GetPosition(goal->gateId);
-        JPH::Vec3 robotPos = bodyInterface.GetPosition(robotBodyId_);
-
-        // Gate opens when the lever is pushed (lever lifts inner end, releasing the gate)
-        bool leverActivated = goal->leverAngle > 0.1f;
-
-        // Also open if robot is directly pushing the gate
-        float dist = (robotPos - gatePos).Length();
-        bool robotPushing = dist < (ROBOT_WIDTH / 2.0f + GATE_THICK + 0.05f);
-
-        if ((leverActivated || robotPushing) && goal->gateOpenAmount < GATE_TRAVEL) {
-            // Open the gate
-            goal->gateOpenAmount += dt * 0.3f; // opens over ~0.5s
-            goal->gateOpenAmount = std::min(goal->gateOpenAmount, GATE_TRAVEL);
-        } else if (!leverActivated && !robotPushing && goal->gateOpenAmount > 0.0f) {
-            // Gravity closes the gate
-            goal->gateOpenAmount -= dt * 0.08f;
-            goal->gateOpenAmount = std::max(goal->gateOpenAmount, 0.0f);
-        }
-
-        // Move the gate: slides in +X direction when opening
-        JPH::Vec3 newPos = gatePos;
         float origX = -HALF_FIELD + GOAL_LEG + CRAMP_LENGTH;
         float rampZ = goal->zSign * HALF_FIELD - goal->zSign * CRAMP_WIDTH / 2.0f;
-        newPos.SetX(origX + goal->gateOpenAmount);
-        newPos.SetZ(rampZ); // keep Z stable
+        float gateCenterY = CRAMP_END_H + GATE_CLOSED_H / 2.0f;
+        JPH::Vec3 closedPos(origX, gateCenterY, rampZ);
 
-        bodyInterface.MoveKinematic(goal->gateId, newPos, JPH::Quat::sIdentity(), dt);
+        JPH::Vec3 robotPos = bodyInterface.GetPosition(robotBodyId_);
+
+        // Gate opens when the lever is pushed or robot is near the gate
+        bool leverActivated = goal->leverAngle > 0.1f;
+        float dist = (robotPos - closedPos).Length();
+        bool robotPushing = dist < (ROBOT_WIDTH / 2.0f + GATE_THICK + 0.08f);
+
+        bool shouldOpen = leverActivated || robotPushing;
+
+        // Binary open/close: move gate out of the way when open, back to position when closed
+        if (shouldOpen) {
+            goal->gateOpenAmount = GATE_TRAVEL;
+            JPH::Vec3 hiddenPos(origX, -1.0f, rampZ); // below the field
+            bodyInterface.MoveKinematic(goal->gateId, hiddenPos, JPH::Quat::sIdentity(), dt);
+        } else {
+            goal->gateOpenAmount = 0.0f;
+            bodyInterface.MoveKinematic(goal->gateId, closedPos, JPH::Quat::sIdentity(), dt);
+        }
     }
 }
 
@@ -800,6 +795,11 @@ void JoltWorld::updateIntake(float dt) {
     // Check for ball pickups if roller is spinning
     if (std::abs(intake_.rollerOmega) < INTAKE_OMEGA_THRESHOLD) return;
 
+    // Pickup: any ball that is close to the robot AND in the front half.
+    // Uses the distance from the ball to the robot's front face center.
+    float frontZ = ROBOT_LENGTH / 2.0f;
+    float pickupRange = INTAKE_BAR_LENGTH + BALL_RADIUS * 3;  // how far past the front face
+
     for (int i = static_cast<int>(balls_.size()) - 1; i >= 0; i--) {
         // Skip recently shot balls
         bool immune = false;
@@ -811,17 +811,19 @@ void JoltWorld::updateIntake(float dt) {
         JPH::Vec3 ballPos = bodyInterface.GetPosition(balls_[i].bodyId);
         JPH::Vec3 localBall = robotRot.Conjugated() * (ballPos - robotPos);
 
-        bool withinWidth = std::abs(localBall.GetX()) < (INTAKE_WIDTH / 2.0f + BALL_RADIUS);
-        bool withinHeight = localBall.GetY() > -BALL_RADIUS && localBall.GetY() < (ROBOT_HEIGHT + BALL_RADIUS * 3);
+        // Ball must be in the front half of the robot or beyond the front face
+        if (localBall.GetZ() < 0.0f) continue;
 
-        // Pick up if ball is near front face — either at roller height or pushed against chassis
-        bool nearFrontFace = localBall.GetZ() > (ROBOT_LENGTH / 2.0f - BALL_RADIUS * 2) &&
-                             localBall.GetZ() < (ROBOT_LENGTH / 2.0f + INTAKE_BAR_LENGTH + BALL_RADIUS * 2);
-        if (nearFrontFace && withinWidth && withinHeight) {
-            // Avoid duplicate entries for the same ball across physics steps
-            if (std::find(pendingPickups_.begin(), pendingPickups_.end(), i) == pendingPickups_.end()) {
-                pendingPickups_.push_back(i);
-            }
+        // Ball must be within the intake width (robot width + ball tolerance)
+        if (std::abs(localBall.GetX()) > INTAKE_WIDTH / 2.0f + BALL_RADIUS) continue;
+
+        // Ball must be close to the front face (not far ahead of the robot)
+        float zPastFront = localBall.GetZ() - frontZ;
+        if (zPastFront > pickupRange) continue;
+
+        // Avoid duplicate entries for the same ball across physics steps
+        if (std::find(pendingPickups_.begin(), pendingPickups_.end(), i) == pendingPickups_.end()) {
+            pendingPickups_.push_back(i);
         }
     }
 

--- a/deps/jolt_sim/src/jolt_world.cpp
+++ b/deps/jolt_sim/src/jolt_world.cpp
@@ -694,8 +694,8 @@ int JoltWorld::spawnShotBall(float x, float y, float z, float vx, float vy, floa
         JPH::BodyLockWrite lock(physicsSystem_->GetBodyLockInterface(), balls_[idx].bodyId);
         if (lock.Succeeded()) {
             auto* mp = lock.GetBody().GetMotionProperties();
-            mp->SetLinearDamping(mp->GetLinearDamping() * 0.15f);
-            mp->SetAngularDamping(mp->GetAngularDamping() * 0.15f);
+            mp->SetLinearDamping(mp->GetLinearDamping() * 0.3f);
+            mp->SetAngularDamping(mp->GetAngularDamping() * 0.3f);
         }
         shotImmunity_.push_back({balls_[idx].bodyId, 0.5f}); // 0.5s immunity
     }

--- a/deps/turret_planner/CMakeLists.txt
+++ b/deps/turret_planner/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(turret_planner STATIC
     src/ballistics.cpp
     src/flight_time.cpp
     src/robust_shot.cpp
+    src/robust_3shot.cpp
     src/path_scan.cpp
     src/preposition.cpp
     src/zone_tracker.cpp
@@ -80,6 +81,10 @@ add_test(NAME flight_time COMMAND test_flight_time)
 add_executable(test_robust_shot tests/test_robust_shot.cpp)
 target_link_libraries(test_robust_shot turret_planner)
 add_test(NAME robust_shot COMMAND test_robust_shot)
+
+add_executable(test_robust_3shot tests/test_robust_3shot.cpp)
+target_link_libraries(test_robust_3shot turret_planner)
+add_test(NAME robust_3shot COMMAND test_robust_3shot)
 
 add_executable(test_path_scan tests/test_path_scan.cpp)
 target_link_libraries(test_path_scan turret_planner)

--- a/deps/turret_planner/include/turret_planner/ballistics.h
+++ b/deps/turret_planner/include/turret_planner/ballistics.h
@@ -81,6 +81,19 @@ bool ballistics_is_feasible(
     float robot_heading = 0.f
 );
 
+// Forward-simulate a shot from (turret_x, turret_y, turret_z) with the given
+// ShotParams and flight time T.  Returns the horizontal miss distance (m) at
+// target height — i.e. how far from (target_x, target_y) the ball lands.
+// Accounts for air drag when cfg.drag_k > 0.
+float ballistics_shot_error(
+    float turret_x, float turret_y, float turret_z,
+    float target_x, float target_y, float target_z,
+    float robot_vx, float robot_vy,
+    const ShotParams& p,
+    float T,
+    const PhysicsConfig& cfg
+);
+
 // dθ/dT standalone (useful for Lipschitz bounds).
 float ballistics_dtheta_dT(float dx, float dy, float vRx, float vRy, float T,
                            const PhysicsConfig& cfg);

--- a/deps/turret_planner/include/turret_planner/ballistics.h
+++ b/deps/turret_planner/include/turret_planner/ballistics.h
@@ -81,8 +81,9 @@ bool ballistics_is_feasible(
     float robot_heading = 0.f
 );
 
-// dθ/dT standalone (matches Kotlin dThetaDT, useful for Lipschitz bounds).
-float ballistics_dtheta_dT(float dx, float dy, float vRx, float vRy, float T);
+// dθ/dT standalone (useful for Lipschitz bounds).
+float ballistics_dtheta_dT(float dx, float dy, float vRx, float vRy, float T,
+                           const PhysicsConfig& cfg);
 
 // Lipschitz bounds on |dθ/dT|, |dφ/dT|, |dv/dT| over [t_lo, t_hi].
 // Used by the cold-start Lipschitz minimizer in flight_time.h.

--- a/deps/turret_planner/include/turret_planner/preposition.h
+++ b/deps/turret_planner/include/turret_planner/preposition.h
@@ -37,12 +37,12 @@ PrepositionResult preposition_compute(
 
 // Robust variant: each sample's shot is solved as the FIRST half of a
 // robust pair against the next path sample (flight_time_robust with the
-// given omega_drop), so the preposition is biased toward turret states
+// given drop_fraction), so the preposition is biased toward turret states
 // that make the *following* shot easy under flywheel loss. The last
 // sample (or any single-sample path) falls back to flight_time_cold.
 //
 // Note: this is NOT equivalent to preposition_compute even when
-// omega_drop == 0, because the two functions optimize different
+// drop_fraction == 0, because the two functions optimize different
 // objectives per sample. preposition_compute minimizes τ from the
 // current turret state to the shot (fastest shot to slew to), while
 // this function minimizes the transition between consecutive shots.
@@ -55,7 +55,7 @@ PrepositionResult preposition_robust_compute(
     float t_available,
     float lambda_decay,
     int   k_samples,
-    float omega_drop,
+    float drop_fraction,
     const TurretWeights& weights,
     const TurretBounds& bounds,
     const PhysicsConfig& cfg,

--- a/deps/turret_planner/include/turret_planner/robust_3shot.h
+++ b/deps/turret_planner/include/turret_planner/robust_3shot.h
@@ -9,22 +9,20 @@
 //
 // Given a predicted trajectory (array of FutureState), a stationary target,
 // and the current turret state, finds when and how to fire up to 3 shots
-// that minimize the total transition cost between consecutive shots.
+// that minimize the total slew cost:
 //
-// Shot timing is deterministic: t2 = t1 + transfer_time, t3 = t1 + 2*transfer_time.
-// The solver sweeps over t1 candidates, and for each one runs a joint B&B over
-// (T1, T2, T3) — the flight times — to minimize:
+//   J = J_0(cur -> s1) + J_12(s1_dropped -> s2) + J_23(s2_dropped -> s3)
 //
-//   J = w_urgency * tau(cur -> s1(T1))
-//     + moveCost(s1(T1)*(1-drop) -> s2(T2))
-//     + moveCost(s2(T2)*(1-drop) -> s3(T3))
+// subject to transition constraints:
+//   J_12 <= transfer_time   (flywheel recovers in time for shot 2)
+//   J_23 <= transfer_time   (flywheel recovers in time for shot 3)
 //
-// where w_urgency = exp(-urgency_lambda * t_remaining) so that the slew to
-// the first shot matters less when there's plenty of preparation time.
+// Solutions violating the constraints are pruned (returned as infeasible).
+// Shot timing is deterministic: t2 = t1 + transfer_time, t3 = t1 + 2*tt.
 //
 // For n_balls < 3, lower terms are omitted:
-//   n_balls=1: J = w_urgency * tau(cur -> s1)
-//   n_balls=2: J = w_urgency * tau(cur -> s1) + moveCost(s1_dropped -> s2)
+//   n_balls=1: J = J_0(cur -> s1)              (no constraint)
+//   n_balls=2: J = J_0 + J_12                  (J_12 <= tt)
 // ---------------------------------------------------------------------------
 
 struct FutureState {
@@ -39,6 +37,7 @@ struct Robust3ShotResult {
     float T1, T2, T3;         // flight times (0 if unused)
     ShotParams s1, s2, s3;    // shot params at each trajectory point
     float J;                   // total objective value
+    float J_12, J_23;         // individual transition costs (for diagnostics)
     bool  feasible;            // true if a valid solution was found
 };
 
@@ -51,7 +50,6 @@ Robust3ShotResult robust_3shot_plan(
     float t_remaining,                 // time until first shot can begin (s)
     float transfer_time,               // minimum time between consecutive shots (s)
     float drop_fraction,               // proportional flywheel speed loss per shot
-    float urgency_lambda,              // decay rate for J_0 weight: w = exp(-lambda*t_remaining)
     const TurretWeights& weights,
     const TurretBounds& bounds,
     const PhysicsConfig& cfg,

--- a/deps/turret_planner/include/turret_planner/robust_3shot.h
+++ b/deps/turret_planner/include/turret_planner/robust_3shot.h
@@ -1,0 +1,61 @@
+#pragma once
+#include "types.h"
+#include "ballistics.h"
+#include "flywheel_model.h"
+#include "flight_time.h"
+
+// ---------------------------------------------------------------------------
+// Trajectory-aware N-shot robust planner (1, 2, or 3 balls).
+//
+// Given a predicted trajectory (array of FutureState), a stationary target,
+// and the current turret state, finds when and how to fire up to 3 shots
+// that minimize the total transition cost between consecutive shots.
+//
+// Shot timing is deterministic: t2 = t1 + transfer_time, t3 = t1 + 2*transfer_time.
+// The solver sweeps over t1 candidates, and for each one runs a joint B&B over
+// (T1, T2, T3) — the flight times — to minimize:
+//
+//   J = w_urgency * tau(cur -> s1(T1))
+//     + moveCost(s1(T1)*(1-drop) -> s2(T2))
+//     + moveCost(s2(T2)*(1-drop) -> s3(T3))
+//
+// where w_urgency = exp(-urgency_lambda * t_remaining) so that the slew to
+// the first shot matters less when there's plenty of preparation time.
+//
+// For n_balls < 3, lower terms are omitted:
+//   n_balls=1: J = w_urgency * tau(cur -> s1)
+//   n_balls=2: J = w_urgency * tau(cur -> s1) + moveCost(s1_dropped -> s2)
+// ---------------------------------------------------------------------------
+
+struct FutureState {
+    float t;           // seconds from now
+    float x, y;        // predicted position (field frame)
+    float heading;     // predicted heading (rad)
+    float vx, vy;      // predicted velocity (field frame, m/s)
+};
+
+struct Robust3ShotResult {
+    int   idx1, idx2, idx3;    // selected trajectory indices (-1 if unused)
+    float T1, T2, T3;         // flight times (0 if unused)
+    ShotParams s1, s2, s3;    // shot params at each trajectory point
+    float J;                   // total objective value
+    bool  feasible;            // true if a valid solution was found
+};
+
+Robust3ShotResult robust_3shot_plan(
+    const FutureState* trajectory, int n_states,
+    float turret_z,
+    float target_x, float target_y, float target_z,
+    const TurretState& current,
+    int   n_balls,                     // 1, 2, or 3
+    float t_remaining,                 // time until first shot can begin (s)
+    float transfer_time,               // minimum time between consecutive shots (s)
+    float drop_fraction,               // proportional flywheel speed loss per shot
+    float urgency_lambda,              // decay rate for J_0 weight: w = exp(-lambda*t_remaining)
+    const TurretWeights& weights,
+    const TurretBounds& bounds,
+    const PhysicsConfig& cfg,
+    const OmegaMapParams& omega,
+    float tol       = 5e-4f,
+    int   maxIter   = 80
+);

--- a/deps/turret_planner/include/turret_planner/robust_shot.h
+++ b/deps/turret_planner/include/turret_planner/robust_shot.h
@@ -12,9 +12,10 @@
 //   J(T1, T2) = max(w_θ|Δθ|, w_φ|Δφ|, w_ω|Δω_adj|)
 //
 // where s1 = ballistics_solve(target1, T1), s2 = ballistics_solve(target2, T2),
-// Δω_adj = (ω(s1.phi, s1.v_exit) - omega_drop) - ω(s2.phi, s2.v_exit).
+// Δω_adj = ω(s1.phi, s1.v_exit)*(1-drop_fraction) - ω(s2.phi, s2.v_exit).
 //
-// This matches ShotSolver.optimalRobustShot on the Kotlin side.
+// drop_fraction models the proportional flywheel speed loss per shot:
+// after firing, the flywheel retains (1-drop_fraction) of its speed.
 // ---------------------------------------------------------------------------
 
 struct RobustShotResult {
@@ -32,7 +33,7 @@ RobustShotResult flight_time_robust(
     float target1_x, float target1_y, float target1_z,
     float target2_x, float target2_y, float target2_z,
     float robot_vx, float robot_vy,
-    float omega_drop,
+    float drop_fraction,
     const TurretWeights& weights,
     const TurretBounds&  bounds,
     const PhysicsConfig& cfg,
@@ -50,7 +51,7 @@ RobustShotResult flight_time_robust(
 //     J(T1, T2) = J_Δ(cur → s1(T1))  +  J_Δ(s1(T1)_reduced → s2(T2))
 //
 // where J_Δ is the max-of-weighted-arms slew time and s1_reduced is s1 with
-// its required flywheel speed decreased by omega_drop. The first term wraps
+// its required flywheel speed scaled by (1-drop_fraction). The first term wraps
 // Δθ to [-π, π] because `cur` may be in a different half-turn than s1; the
 // second term matches the plain flight_time_robust convention (no wrap).
 // ---------------------------------------------------------------------------
@@ -60,7 +61,7 @@ RobustShotResult flight_time_robust_adjust(
     float target2_x, float target2_y, float target2_z,
     float robot_vx, float robot_vy,
     const TurretState& current,
-    float omega_drop,
+    float drop_fraction,
     const TurretWeights& weights,
     const TurretBounds&  bounds,
     const PhysicsConfig& cfg,

--- a/deps/turret_planner/include/turret_planner/types.h
+++ b/deps/turret_planner/include/turret_planner/types.h
@@ -65,8 +65,9 @@ struct TurretWeights {
 
 // Physical constants for ballistics.
 struct PhysicsConfig {
-    float g;    // gravitational acceleration (m/s^2, positive downward, ~9.81)
-    float r_h;  // barrel offset: distance from turret pivot to launch point (m)
+    float g;       // gravitational acceleration (m/s^2, positive downward, ~9.81)
+    float r_h;     // barrel offset: distance from turret pivot to launch point (m)
+    float drag_k;  // linear air drag coefficient (1/s), 0 = no drag
 };
 
 // Configuration for zone-entry tracker.

--- a/deps/turret_planner/jni/turret_planner_jni.cpp
+++ b/deps/turret_planner/jni/turret_planner_jni.cpp
@@ -109,6 +109,30 @@ Java_sigmacorns_control_aim_TurretPlannerBridge_solve(
 }
 
 // ---------------------------------------------------------------------------
+// JNI: shotError
+// Forward-simulate a shot and return the horizontal miss distance (m).
+// ---------------------------------------------------------------------------
+extern "C" JNIEXPORT jfloat JNICALL
+Java_sigmacorns_control_aim_TurretPlannerBridge_shotError(
+    JNIEnv* env, jobject,
+    jfloat turretX, jfloat turretY, jfloat turretZ,
+    jfloat targetX, jfloat targetY, jfloat targetZ,
+    jfloat robotVx, jfloat robotVy,
+    jfloat theta, jfloat phi, jfloat vExit, jfloat omega,
+    jfloat T,
+    jfloatArray jPhys)
+{
+    ScopedArray ph(env, jPhys);
+    if (!ph) return 1e9f;
+    ShotParams p{theta, phi, vExit, omega};
+    return ballistics_shot_error(
+        turretX, turretY, turretZ,
+        targetX, targetY, targetZ,
+        robotVx, robotVy, p, T,
+        unpack_physics(ph));
+}
+
+// ---------------------------------------------------------------------------
 // JNI: optimalTCold
 // Returns [T*, tau, theta, phi, vExit, omega, feasible(0|1)]
 // ---------------------------------------------------------------------------
@@ -394,10 +418,10 @@ Java_sigmacorns_control_aim_TurretPlannerBridge_computeRobustPreposition(
 // ---------------------------------------------------------------------------
 // JNI: robust3ShotPlan
 // trajectory: flat FloatArray, 6 floats/state [t, x, y, heading, vx, vy]
-// Returns [feasible, idx1, idx2, idx3, J, T1, T2, T3,
+// Returns [feasible, idx1, idx2, idx3, J, J_12, J_23, T1, T2, T3,
 //          s1.theta, s1.phi, s1.vExit, s1.omega,
 //          s2.theta, s2.phi, s2.vExit, s2.omega,
-//          s3.theta, s3.phi, s3.vExit, s3.omega]   = 20 floats
+//          s3.theta, s3.phi, s3.vExit, s3.omega]   = 22 floats
 // ---------------------------------------------------------------------------
 extern "C" JNIEXPORT jfloatArray JNICALL
 Java_sigmacorns_control_aim_TurretPlannerBridge_robust3ShotPlan(
@@ -410,7 +434,6 @@ Java_sigmacorns_control_aim_TurretPlannerBridge_robust3ShotPlan(
     jfloat tRemaining,
     jfloat transferTime,
     jfloat dropFraction,
-    jfloat urgencyLambda,
     jfloatArray jWeights,
     jfloatArray jBounds,
     jfloatArray jPhys,
@@ -423,7 +446,6 @@ Java_sigmacorns_control_aim_TurretPlannerBridge_robust3ShotPlan(
                         ph(env, jPhys),   om(env, jOmega);
     if (!traj || !w || !b || !ph || !om) return nullptr;
 
-    // FutureState is 6 floats: t, x, y, heading, vx, vy
     static_assert(sizeof(FutureState) == 6 * sizeof(float), "FutureState layout mismatch");
     const FutureState* states = reinterpret_cast<const FutureState*>(traj.ptr);
 
@@ -433,21 +455,21 @@ Java_sigmacorns_control_aim_TurretPlannerBridge_robust3ShotPlan(
         targetX, targetY, targetZ,
         unpack_turret(curTheta, curPhi, curOmega),
         (int)nBalls,
-        tRemaining, transferTime, dropFraction, urgencyLambda,
+        tRemaining, transferTime, dropFraction,
         unpack_weights(w), unpack_bounds(b),
         unpack_physics(ph), unpack_omega(om),
         tol, (int)maxIter);
 
-    float buf[20] = {
+    float buf[22] = {
         r.feasible ? 1.f : 0.f,
         float(r.idx1), float(r.idx2), float(r.idx3),
-        r.J,
+        r.J, r.J_12, r.J_23,
         r.T1, r.T2, r.T3,
         r.s1.theta, r.s1.phi, r.s1.v_exit, r.s1.omega_flywheel,
         r.s2.theta, r.s2.phi, r.s2.v_exit, r.s2.omega_flywheel,
         r.s3.theta, r.s3.phi, r.s3.v_exit, r.s3.omega_flywheel
     };
-    return make_result(env, buf, 20);
+    return make_result(env, buf, 22);
 }
 
 // ---------------------------------------------------------------------------

--- a/deps/turret_planner/jni/turret_planner_jni.cpp
+++ b/deps/turret_planner/jni/turret_planner_jni.cpp
@@ -5,6 +5,7 @@
 #include "turret_planner/ballistics.h"
 #include "turret_planner/flight_time.h"
 #include "turret_planner/robust_shot.h"
+#include "turret_planner/robust_3shot.h"
 #include "turret_planner/path_scan.h"
 #include "turret_planner/preposition.h"
 #include "turret_planner/zone_tracker.h"
@@ -12,7 +13,7 @@
 
 // ---------------------------------------------------------------------------
 // Config-array layouts (match TurretPlannerBridge.kt constants)
-//   physConfig  [2]:  g, rH
+//   physConfig  [3]:  g, rH, dragK
 //   bounds      [6]:  thetaMin, thetaMax, phiMin, phiMax, vExitMax, omegaMax
 //   weights     [3]:  wTheta, wPhi, wOmega
 //   omegaCoeffs [6]:  c0..c5
@@ -26,7 +27,7 @@
 // ---------------------------------------------------------------------------
 
 static inline PhysicsConfig unpack_physics(const jfloat* p) {
-    return PhysicsConfig{p[0], p[1]};
+    return PhysicsConfig{p[0], p[1], p[2]};
 }
 
 static inline TurretBounds unpack_bounds(const jfloat* p) {
@@ -272,7 +273,7 @@ Java_sigmacorns_control_aim_TurretPlannerBridge_robustShot(
     jfloat t1X, jfloat t1Y, jfloat t1Z,
     jfloat t2X, jfloat t2Y, jfloat t2Z,
     jfloat robotVx, jfloat robotVy,
-    jfloat omegaDrop,
+    jfloat dropFraction,
     jfloatArray jWeights,
     jfloatArray jBounds,
     jfloatArray jPhys,
@@ -288,7 +289,7 @@ Java_sigmacorns_control_aim_TurretPlannerBridge_robustShot(
         turretX, turretY, turretZ,
         t1X, t1Y, t1Z,
         t2X, t2Y, t2Z,
-        robotVx, robotVy, omegaDrop,
+        robotVx, robotVy, dropFraction,
         unpack_weights(w), unpack_bounds(b),
         unpack_physics(ph), unpack_omega(om),
         tol, (int)maxIter);
@@ -317,7 +318,7 @@ Java_sigmacorns_control_aim_TurretPlannerBridge_robustAdjust(
     jfloat t2X, jfloat t2Y, jfloat t2Z,
     jfloat robotVx, jfloat robotVy,
     jfloat curTheta, jfloat curPhi, jfloat curOmega,
-    jfloat omegaDrop,
+    jfloat dropFraction,
     jfloatArray jWeights,
     jfloatArray jBounds,
     jfloatArray jPhys,
@@ -335,7 +336,7 @@ Java_sigmacorns_control_aim_TurretPlannerBridge_robustAdjust(
         t2X, t2Y, t2Z,
         robotVx, robotVy,
         unpack_turret(curTheta, curPhi, curOmega),
-        omegaDrop,
+        dropFraction,
         unpack_weights(w), unpack_bounds(b),
         unpack_physics(ph), unpack_omega(om),
         tol, (int)maxIter);
@@ -364,7 +365,7 @@ Java_sigmacorns_control_aim_TurretPlannerBridge_computeRobustPreposition(
     jfloat tAvailable,
     jfloat lambdaDecay,
     jint   kSamples,
-    jfloat omegaDrop,
+    jfloat dropFraction,
     jfloatArray jWeights,
     jfloatArray jBounds,
     jfloatArray jPhys,
@@ -382,12 +383,71 @@ Java_sigmacorns_control_aim_TurretPlannerBridge_computeRobustPreposition(
         turretX, turretY, turretZ,
         robotVx, robotVy, targetZ,
         unpack_turret(curTheta, curPhi, curOmega),
-        tAvailable, lambdaDecay, (int)kSamples, omegaDrop,
+        tAvailable, lambdaDecay, (int)kSamples, dropFraction,
         unpack_weights(w), unpack_bounds(b), unpack_physics(ph), unpack_omega(om));
 
     float buf[4] = {r.target.theta, r.target.phi, r.target.omega_flywheel,
                     r.expected_earliest_t};
     return make_result(env, buf, 4);
+}
+
+// ---------------------------------------------------------------------------
+// JNI: robust3ShotPlan
+// trajectory: flat FloatArray, 6 floats/state [t, x, y, heading, vx, vy]
+// Returns [feasible, idx1, idx2, idx3, J, T1, T2, T3,
+//          s1.theta, s1.phi, s1.vExit, s1.omega,
+//          s2.theta, s2.phi, s2.vExit, s2.omega,
+//          s3.theta, s3.phi, s3.vExit, s3.omega]   = 20 floats
+// ---------------------------------------------------------------------------
+extern "C" JNIEXPORT jfloatArray JNICALL
+Java_sigmacorns_control_aim_TurretPlannerBridge_robust3ShotPlan(
+    JNIEnv* env, jobject,
+    jfloatArray jTrajectory, jint nStates,
+    jfloat turretZ,
+    jfloat targetX, jfloat targetY, jfloat targetZ,
+    jfloat curTheta, jfloat curPhi, jfloat curOmega,
+    jint   nBalls,
+    jfloat tRemaining,
+    jfloat transferTime,
+    jfloat dropFraction,
+    jfloat urgencyLambda,
+    jfloatArray jWeights,
+    jfloatArray jBounds,
+    jfloatArray jPhys,
+    jfloatArray jOmega,
+    jfloat tol,
+    jint   maxIter)
+{
+    ScopedArray traj(env, jTrajectory);
+    ScopedArray w(env, jWeights), b(env, jBounds),
+                        ph(env, jPhys),   om(env, jOmega);
+    if (!traj || !w || !b || !ph || !om) return nullptr;
+
+    // FutureState is 6 floats: t, x, y, heading, vx, vy
+    static_assert(sizeof(FutureState) == 6 * sizeof(float), "FutureState layout mismatch");
+    const FutureState* states = reinterpret_cast<const FutureState*>(traj.ptr);
+
+    Robust3ShotResult r = robust_3shot_plan(
+        states, (int)nStates,
+        turretZ,
+        targetX, targetY, targetZ,
+        unpack_turret(curTheta, curPhi, curOmega),
+        (int)nBalls,
+        tRemaining, transferTime, dropFraction, urgencyLambda,
+        unpack_weights(w), unpack_bounds(b),
+        unpack_physics(ph), unpack_omega(om),
+        tol, (int)maxIter);
+
+    float buf[20] = {
+        r.feasible ? 1.f : 0.f,
+        float(r.idx1), float(r.idx2), float(r.idx3),
+        r.J,
+        r.T1, r.T2, r.T3,
+        r.s1.theta, r.s1.phi, r.s1.v_exit, r.s1.omega_flywheel,
+        r.s2.theta, r.s2.phi, r.s2.v_exit, r.s2.omega_flywheel,
+        r.s3.theta, r.s3.phi, r.s3.v_exit, r.s3.omega_flywheel
+    };
+    return make_result(env, buf, 20);
 }
 
 // ---------------------------------------------------------------------------

--- a/deps/turret_planner/src/ballistics.cpp
+++ b/deps/turret_planner/src/ballistics.cpp
@@ -217,6 +217,47 @@ ShotParams ballistics_solve_with_derivs(
 }
 
 // ---------------------------------------------------------------------------
+// ballistics_shot_error — forward-simulate and measure miss distance
+// ---------------------------------------------------------------------------
+
+float ballistics_shot_error(
+    float turret_x, float turret_y, float turret_z,
+    float target_x, float target_y, float target_z,
+    float robot_vx, float robot_vy,
+    const ShotParams& p,
+    float T,
+    const PhysicsConfig& cfg)
+{
+    float sin_theta, cos_theta, sin_phi, cos_phi;
+    fast_sincos(p.theta, &sin_theta, &cos_theta);
+    fast_sincos(p.phi, &sin_phi, &cos_phi);
+
+    // Launch position (barrel offset)
+    float sx = turret_x + cfg.r_h * (1.f - sin_phi) * cos_theta;
+    float sy = turret_y + cfg.r_h * (1.f - sin_phi) * sin_theta;
+
+    // Launch velocity components in field frame
+    float vx0 = p.v_exit * cos_phi * cos_theta + robot_vx;
+    float vy0 = p.v_exit * cos_phi * sin_theta + robot_vy;
+
+    float xf, yf;
+    if (cfg.drag_k > 1e-6f) {
+        // With drag: pos(T) = pos0 + v0/k * (1 - exp(-kT))
+        float k = cfg.drag_k;
+        float decay = (1.f - std::exp(-k * T)) / k;
+        xf = sx + vx0 * decay;
+        yf = sy + vy0 * decay;
+    } else {
+        xf = sx + vx0 * T;
+        yf = sy + vy0 * T;
+    }
+
+    float dx = xf - target_x;
+    float dy = yf - target_y;
+    return fast_sqrt(dx * dx + dy * dy);
+}
+
+// ---------------------------------------------------------------------------
 // ballistics_is_feasible
 // ---------------------------------------------------------------------------
 
@@ -480,11 +521,26 @@ TInterval ballistics_feasible_interval(
     }
 
     // Check if any feasible T exists in (0, T_upper_bound]
+    // Precompute unit target direction for the forward-shot check.
+    float dist_sq = dx * dx + dy * dy;
+
     auto is_feas = [&](float T) -> bool {
         if (T <= 0.f) return false;
         ShotParams p = ballistics_solve(0,0,0, dx,dy,dz, vRx,vRy, T, cfg,
                                         OmegaMapParams{});
-        return ballistics_is_feasible(p, T, bounds, cfg);
+        if (!ballistics_is_feasible(p, T, bounds, cfg)) return false;
+
+        // Reject backwards-pointing shots: the launch direction must have
+        // a positive component along the geometric target direction.
+        // When the robot's velocity dominates dx/T (or dy/T), atan2 can
+        // flip theta ~180°, producing a physically valid but impractical
+        // solution where the turret points away from the goal.
+        if (dist_sq > 1e-6f) {
+            float dot = std::cos(p.theta) * dx + std::sin(p.theta) * dy;
+            if (dot <= 0.f) return false;
+        }
+
+        return true;
     };
 
     // Phase 1: coarse sweep to find the outer feasible envelope.

--- a/deps/turret_planner/src/ballistics.cpp
+++ b/deps/turret_planner/src/ballistics.cpp
@@ -23,16 +23,32 @@ BallisticsIntermediate ballistics_intermediate(
     s.dx  = dx;  s.dy  = dy;  s.dz  = dz;
     s.vRx = vRx; s.vRy = vRy;
 
+    // alpha replaces 1/T when drag is present.
+    // No drag:   alpha = 1/T
+    // With drag: alpha = k / (1 - exp(-k*T))
+    // The correction accounts for exponential velocity decay: horizontal
+    // distance = v0/k * (1 - exp(-kT)) instead of v0*T.
     float inv_T = 1.f / T;
-    s.b = dx * inv_T - vRx;
-    s.c = dy * inv_T - vRy;
-    s.a = -cfg.r_h * inv_T;
+    float alpha;
+    if (cfg.drag_k > 1e-6f) {
+        float kT = cfg.drag_k * T;
+        float exp_neg_kT = std::exp(-kT);
+        alpha = cfg.drag_k / (1.f - exp_neg_kT);
+        // Vertical: with drag, z(T) = (vz + g/k)/k * (1-e^{-kT}) - g*T/k = dz
+        // Solving for the "C" combination:
+        s.C = (dz + cfg.g * T / cfg.drag_k) * alpha - cfg.g / cfg.drag_k;
+    } else {
+        alpha = inv_T;
+        s.C = dz * inv_T + 0.5f * cfg.g * T;
+    }
+    s.b = dx * alpha - vRx;
+    s.c = dy * alpha - vRy;
+    s.a = -cfg.r_h * alpha;
 
     s.theta = fast_atan2(s.c, s.b);
     fast_sincos(s.theta, &s.sin_theta, &s.cos_theta);
 
     s.B = s.a + s.cos_theta * s.b + s.sin_theta * s.c;
-    s.C = dz * inv_T + 0.5f * cfg.g * T;
 
     float v_sq = s.B * s.B + s.C * s.C - s.a * s.a;
     // v_sq < 0 can happen outside the feasible T range — clamp to 0.
@@ -126,21 +142,42 @@ ShotParams ballistics_solve_with_derivs(
         float inv_T  = 1.f / T;
         float inv_T2 = inv_T * inv_T;
 
+        // d(alpha)/dT: derivative of the horizontal correction factor
+        float dalpha_dT;
+        float dC_dT;
+        if (cfg.drag_k > 1e-6f) {
+            float k = cfg.drag_k;
+            float kT = k * T;
+            float exp_neg_kT = std::exp(-kT);
+            float one_minus_exp = 1.f - exp_neg_kT;
+            // alpha = k / (1 - exp(-kT))
+            // d(alpha)/dT = -k^2 * exp(-kT) / (1-exp(-kT))^2
+            dalpha_dT = -k * k * exp_neg_kT / (one_minus_exp * one_minus_exp);
+            // C = (dz + g*T/k) * alpha - g/k
+            // dC/dT = (g/k) * alpha + (dz + g*T/k) * dalpha/dT
+            float alpha = k / one_minus_exp;
+            dC_dT = (cfg.g / k) * alpha + (dz + cfg.g * T / k) * dalpha_dT;
+        } else {
+            // alpha = 1/T, d(alpha)/dT = -1/T^2
+            dalpha_dT = -inv_T2;
+            dC_dT = -dz * inv_T2 + 0.5f * cfg.g;
+        }
+
         // --- dθ/dT ---
+        // b = dx*alpha - vRx, c = dy*alpha - vRy
+        // db/dT = dx * dalpha_dT, dc/dT = dy * dalpha_dT
+        // dθ/dT = (dc/dT * b - db/dT * c) / (b² + c²)
+        //       = dalpha_dT * (dy*b - dx*c) / (b²+c²)
         float bc_sq = s.b * s.b + s.c * s.c;
-        // Simplified: dθ/dT = (dy*vRx - dx*vRy) / (T² * bc_sq)
-        float dtheta_dT = (dy * robot_vx - dx * robot_vy) / (T * T * bc_sq);
+        float dtheta_dT = dalpha_dT * (dy * s.b - dx * s.c) / bc_sq;
 
         // --- dB/dT ---
-        float db_dT  = -dx * inv_T2;
-        float dc_dT  = -dy * inv_T2;
-        float da_dT  =  cfg.r_h * inv_T2;
+        float db_dT  = dx * dalpha_dT;
+        float dc_dT  = dy * dalpha_dT;
+        float da_dT  = -cfg.r_h * dalpha_dT;
         float dB_dT  = da_dT
                      + (-s.sin_theta * dtheta_dT) * s.b + s.cos_theta * db_dT
                      + ( s.cos_theta * dtheta_dT) * s.c + s.sin_theta * dc_dT;
-
-        // --- dC/dT ---
-        float dC_dT  = -dz * inv_T2 + 0.5f * cfg.g;
 
         // --- dv/dT ---
         // 2v * dv/dT = 2B*dB/dT + 2C*dC/dT - 2a*da_dT
@@ -203,8 +240,15 @@ bool ballistics_is_feasible(
     }
 
     // Lob check: vertical velocity at T must be < 0 (ball descending at target).
-    // Matches Kotlin isLob: vz < 0 (strictly negative; horizontal at impact is not a lob).
-    float vz_at_T = p.v_exit * std::sin(p.phi) - cfg.g * T;
+    float vz_at_T;
+    if (cfg.drag_k > 1e-6f) {
+        // With drag: vz(T) = (vz0 + g/k) * exp(-kT) - g/k
+        float vz0 = p.v_exit * std::sin(p.phi);
+        float g_over_k = cfg.g / cfg.drag_k;
+        vz_at_T = (vz0 + g_over_k) * std::exp(-cfg.drag_k * T) - g_over_k;
+    } else {
+        vz_at_T = p.v_exit * std::sin(p.phi) - cfg.g * T;
+    }
     return vz_at_T < 0.f;
 }
 
@@ -212,12 +256,24 @@ bool ballistics_is_feasible(
 // ballistics_dtheta_dT
 // ---------------------------------------------------------------------------
 
-float ballistics_dtheta_dT(float dx, float dy, float vRx, float vRy, float T)
+float ballistics_dtheta_dT(float dx, float dy, float vRx, float vRy, float T,
+                           const PhysicsConfig& cfg)
 {
-    float b = dx / T - vRx;
-    float c = dy / T - vRy;
-    // Simplified form: numerator = (dy*vRx - dx*vRy) / T²
-    return (dy * vRx - dx * vRy) / (T * T * (b * b + c * c));
+    float alpha, dalpha_dT;
+    if (cfg.drag_k > 1e-6f) {
+        float kT = cfg.drag_k * T;
+        float exp_neg_kT = std::exp(-kT);
+        float one_minus_exp = 1.f - exp_neg_kT;
+        alpha = cfg.drag_k / one_minus_exp;
+        dalpha_dT = -cfg.drag_k * cfg.drag_k * exp_neg_kT / (one_minus_exp * one_minus_exp);
+    } else {
+        alpha = 1.f / T;
+        dalpha_dT = -1.f / (T * T);
+    }
+    float b = dx * alpha - vRx;
+    float c = dy * alpha - vRy;
+    // dθ/dT = dalpha_dT * (dy*b - dx*c) / (b²+c²)
+    return dalpha_dT * (dy * b - dx * c) / (b * b + c * c);
 }
 
 // ---------------------------------------------------------------------------
@@ -232,56 +288,80 @@ LipschitzBounds ballistics_lipschitz(
     float t_lo, float t_hi,
     const PhysicsConfig& cfg)
 {
-    // --- L_theta ---
-    float cross_term = dy * vRx - dx * vRy;
-    float num_up = std::abs(cross_term) / (t_lo * t_lo);
+    // Helper: compute alpha(t) for drag-corrected ballistics
+    auto compute_alpha = [&](float t) -> float {
+        if (cfg.drag_k > 1e-6f) {
+            float kT = cfg.drag_k * t;
+            return cfg.drag_k / (1.f - std::exp(-kT));
+        }
+        return 1.f / t;
+    };
 
-    // Denominator = b²+c²; minimize over [t_lo, t_hi]
+    // Helper: compute d(alpha)/dT
+    auto compute_dalpha_dT = [&](float t) -> float {
+        if (cfg.drag_k > 1e-6f) {
+            float k = cfg.drag_k;
+            float kT = k * t;
+            float exp_neg_kT = std::exp(-kT);
+            float one_minus_exp = 1.f - exp_neg_kT;
+            return -k * k * exp_neg_kT / (one_minus_exp * one_minus_exp);
+        }
+        return -1.f / (t * t);
+    };
+
+    // Helper: compute C(t) for the vertical ballistics equation
+    auto compute_C = [&](float t) -> float {
+        if (cfg.drag_k > 1e-6f) {
+            float alpha = compute_alpha(t);
+            return (dz + cfg.g * t / cfg.drag_k) * alpha - cfg.g / cfg.drag_k;
+        }
+        return dz / t + 0.5f * cfg.g * t;
+    };
+
+    // --- L_theta ---
+    // With drag: b = dx*alpha - vRx, c = dy*alpha - vRy
+    // dθ/dT = dalpha_dT * (dy*b - dx*c) / (b²+c²)
+    // Sample |dθ/dT| to get a tight bound.
+    float l_theta = 0.f;
+
+    // Denominator = b²+c²; minimize over [t_lo, t_hi] via sampling
     auto bc_sq = [&](float t) {
-        float b = dx / t - vRx;
-        float c = dy / t - vRy;
+        float alpha = compute_alpha(t);
+        float b = dx * alpha - vRx;
+        float c = dy * alpha - vRy;
         return b * b + c * c;
     };
     float den_lo = std::min(bc_sq(t_lo), bc_sq(t_hi));
-    // Check zeros of b(T) = dx/vRx and c(T) = dy/vRy
-    if (std::abs(vRx) > 1e-9f) {
-        float tc = dx / vRx;
-        if (tc >= t_lo && tc <= t_hi) {
-            float c = dy / tc - vRy;
-            den_lo = std::min(den_lo, c * c);
-        }
+    // Sample interior for minimum
+    for (int i = 1; i < 16; ++i) {
+        float t = t_lo + (t_hi - t_lo) * float(i) / 16.f;
+        den_lo = std::min(den_lo, bc_sq(t));
     }
-    if (std::abs(vRy) > 1e-9f) {
-        float tc = dy / vRy;
-        if (tc >= t_lo && tc <= t_hi) {
-            float b = dx / tc - vRx;
-            den_lo = std::min(den_lo, b * b);
-        }
-    }
-    // Guard against degenerate case
     if (den_lo < 1e-12f) den_lo = 1e-12f;
-    float l_theta = num_up / den_lo;
 
     // --- L_B and L_phi (sample N points, denser near t_lo where derivatives spike) ---
-    // L_phi is evaluated analytically at each sample — the analytical formula is exact,
-    // but the interval-based bound can under-estimate when B→0 near t_lo.
-    // Sampling the analytical derivative directly gives a tight floor.
     float l_B        = 0.f;
     float l_phi_samp = 0.f;
-    // Use 64 samples; cluster the first 16 near t_lo (where phi' spikes) and
-    // the remaining 48 uniformly over the rest of the interval.
     const int N_lo = 16, N_rest = 48;
-    // Near-boundary region: first 5% of interval
     float t_near = t_lo + 0.05f * (t_hi - t_lo);
 
     auto process_sample = [&](float t) {
-        // L_B contribution
-        float b = dx / t - vRx;
-        float c = dy / t - vRy;
-        float dtdT = ballistics_dtheta_dT(dx, dy, vRx, vRy, t);
-        float term1 = dtdT * c - dx / (t * t);
-        float term2 = dtdT * b + dy / (t * t);
-        l_B = std::max(l_B, cfg.r_h / (t * t) + fast_sqrt(term1 * term1 + term2 * term2));
+        float alpha = compute_alpha(t);
+        float dalpha = compute_dalpha_dT(t);
+        float b = dx * alpha - vRx;
+        float c = dy * alpha - vRy;
+        float dtdT = ballistics_dtheta_dT(dx, dy, vRx, vRy, t, cfg);
+
+        // |dθ/dT| for L_theta
+        l_theta = std::max(l_theta, std::abs(dtdT));
+
+        // L_B contribution: |dB/dT| upper bound via Cauchy-Schwarz
+        float db_dT = dx * dalpha;
+        float dc_dT = dy * dalpha;
+        float term1 = dtdT * c + dc_dT;  // from sin(θ) component
+        float term2 = dtdT * b + db_dT;  // from cos(θ) component — sign doesn't matter for norm
+        float da_dT = -cfg.r_h * dalpha;
+        l_B = std::max(l_B, std::abs(da_dT) + fast_sqrt(term1 * term1 + term2 * term2));
 
         // Analytical |dφ/dT| — reuse solve_with_derivs intermediates
         if (t > 0.f) {
@@ -302,7 +382,6 @@ LipschitzBounds ballistics_lipschitz(
     }
 
     // --- Bounds on B, C, C' for L_v and L_phi ---
-    // Evaluate B at midpoint for B0
     float t_mid = 0.5f * (t_lo + t_hi);
     BallisticsIntermediate s_mid = ballistics_intermediate(dx, dy, dz, vRx, vRy, t_mid, cfg);
     float B0  = s_mid.B;
@@ -310,35 +389,46 @@ LipschitzBounds ballistics_lipschitz(
     float B_up  = std::abs(B0) + l_B * delta_T;
     float B_lo  = std::max(std::abs(B0) - l_B * delta_T, 0.f);
 
-    // C(t) = dz/t + g/2*t; monotone if dz > 0 else has minimum at t = sqrt(2dz/g)
-    float c_lo_t = dz / t_lo + 0.5f * cfg.g * t_lo;
-    float c_hi_t = dz / t_hi + 0.5f * cfg.g * t_hi;
+    // C bounds via sampling (handles both drag and no-drag cases)
+    float c_lo_t = compute_C(t_lo);
+    float c_hi_t = compute_C(t_hi);
     float C_max  = std::max(std::abs(c_lo_t), std::abs(c_hi_t));
-    float C_min;
-    if (dz >= 0.f) {
-        float tc = fast_sqrt(2.f * dz / cfg.g);
-        if (tc >= t_lo && tc <= t_hi)
-            C_min = fast_sqrt(2.f * cfg.g * dz);
-        else
-            C_min = std::min(std::abs(c_lo_t), std::abs(c_hi_t));
-    } else {
-        C_min = std::min(std::abs(c_lo_t), std::abs(c_hi_t));
+    float C_min  = std::min(std::abs(c_lo_t), std::abs(c_hi_t));
+    // Sample interior for C_min/C_max (handles both drag and no-drag)
+    for (int i = 1; i < 16; ++i) {
+        float t = t_lo + (t_hi - t_lo) * float(i) / 16.f;
+        float C_t = compute_C(t);
+        C_max = std::max(C_max, std::abs(C_t));
+        C_min = std::min(C_min, std::abs(C_t));
     }
 
-    float Cp_lo = -dz / (t_lo * t_lo) + 0.5f * cfg.g;
-    float Cp_hi = -dz / (t_hi * t_hi) + 0.5f * cfg.g;
-    float C_prime_max = std::max(std::abs(Cp_lo), std::abs(Cp_hi));
+    // C'(t) = dC/dT bounds via sampling
+    float C_prime_max = 0.f;
+    for (int i = 0; i <= 16; ++i) {
+        float t = t_lo + (t_hi - t_lo) * float(i) / 16.f;
+        // Finite difference approximation of dC/dT
+        float dt_fd = (t_hi - t_lo) * 1e-4f;
+        if (dt_fd < 1e-8f) dt_fd = 1e-8f;
+        float t_p = std::min(t + dt_fd, t_hi);
+        float t_m = std::max(t - dt_fd, t_lo);
+        float Cp = (compute_C(t_p) - compute_C(t_m)) / (t_p - t_m);
+        C_prime_max = std::max(C_prime_max, std::abs(Cp));
+    }
 
-    // v² = B²+C²-a²; lower-bound v
-    float a_max_sq = sq(cfg.r_h / t_lo);
+    // v² = B²+C²-a²; lower-bound v.
+    // a = -r_h * alpha(t); |a|_max occurs at the smallest t (largest alpha)
+    float alpha_max = compute_alpha(t_lo);
+    float a_max_sq = sq(cfg.r_h * alpha_max);
     float v_sq_lo  = std::max(B_lo * B_lo + C_min * C_min - a_max_sq, 0.f);
     float v_lo_val = fast_sqrt(v_sq_lo);
     float v_up     = fast_sqrt(B_up * B_up + C_max * C_max);
 
+    // L_v: dv/dT = (B*dB/dT + C*dC/dT - a*da/dT) / v
+    // Upper bound: (|B|_max * L_B + |C|_max * C'_max + |a|_max * |da/dT|_max) / v_lo
+    float da_dT_max = cfg.r_h * std::abs(compute_dalpha_dT(t_lo)); // largest at t_lo
     float l_v = 0.f;
     if (v_lo_val > 1e-6f) {
-        l_v = (l_B * B_up + 0.25f * cfg.g * cfg.g * t_hi
-               + (cfg.r_h * cfg.r_h + dz * dz) / (t_lo * t_lo * t_lo)) / v_lo_val;
+        l_v = (l_B * B_up + C_max * C_prime_max + alpha_max * cfg.r_h * da_dT_max) / v_lo_val;
     } else {
         l_v = 1e6f; // degenerate
     }
@@ -348,8 +438,8 @@ LipschitzBounds ballistics_lipschitz(
     float l_phi = 0.f;
     if (denom_phi > 1e-12f) {
         l_phi = (C_prime_max * B_up + l_B * C_max
-                 + (cfg.r_h / (t_lo * t_lo)) * v_up
-                 + l_v * (cfg.r_h / t_lo)) / denom_phi;
+                 + alpha_max * cfg.r_h * v_up
+                 + l_v * cfg.r_h * alpha_max) / denom_phi;
     } else {
         l_phi = 1e6f;
     }
@@ -371,9 +461,10 @@ TInterval ballistics_feasible_interval(
     const PhysicsConfig& cfg,
     float tol)
 {
-    // Upper bound on T: the trajectory that maximizes height.
-    // At phi=45° approximately the maximum range case; use vMax at phi=pi/4.
-    // Matches Kotlin tBounds: solve g/2*T^2 - vMax/sqrt(2)*T + (dz - r_h/sqrt(2)) = 0
+    // Upper bound on T: the trajectory that maximizes flight time.
+    // No-drag: solve g/2*T^2 - vMax/sqrt(2)*T + (dz - r_h/sqrt(2)) = 0
+    // With drag the ball decelerates so max flight time increases; we apply a
+    // generous multiplier to avoid cutting off feasible solutions.
     float a_coef = cfg.g / 2.f;
     float b_coef = -bounds.v_exit_max / 1.41421356f;
     float c_coef =  dz - cfg.r_h / 1.41421356f;
@@ -383,6 +474,11 @@ TInterval ballistics_feasible_interval(
     float T_upper_bound = (-b_coef + fast_sqrt(disc)) / (2.f * a_coef);
     if (T_upper_bound <= 0.f) return {0.f, 0.f};
 
+    // With drag, flight times are longer (velocity decays); scale up the bound.
+    if (cfg.drag_k > 1e-6f) {
+        T_upper_bound *= (1.f + cfg.drag_k * T_upper_bound);
+    }
+
     // Check if any feasible T exists in (0, T_upper_bound]
     auto is_feas = [&](float T) -> bool {
         if (T <= 0.f) return false;
@@ -391,17 +487,37 @@ TInterval ballistics_feasible_interval(
         return ballistics_is_feasible(p, T, bounds, cfg);
     };
 
-    // Binary search for t_max (upper edge of feasible window — the lob/speed limit)
-    float lo = 0.f, hi = T_upper_bound;
+    // Phase 1: coarse sweep to find the outer feasible envelope.
+    // The lob constraint can make feasibility non-monotone in T, so a single
+    // binary search may miss the true boundary. Sweep first, refine second.
+    const int N_SWEEP = 64;
+    float dt_sweep = T_upper_bound / float(N_SWEEP);
+    float global_t_min = T_upper_bound;
+    float global_t_max = 0.f;
+
+    for (int i = 1; i <= N_SWEEP; ++i) {
+        float t = float(i) * dt_sweep;
+        if (is_feas(t)) {
+            global_t_min = std::min(global_t_min, t);
+            global_t_max = std::max(global_t_max, t);
+        }
+    }
+
+    if (global_t_max <= 0.f) return {0.f, 0.f};
+
+    // Phase 2: binary-search refine the outer edges of the feasible region.
+    // Refine t_max in [global_t_max, global_t_max + dt_sweep]
+    float lo = global_t_max;
+    float hi = std::min(global_t_max + dt_sweep, T_upper_bound);
     while (hi - lo > tol) {
         float m = 0.5f * (lo + hi);
         if (is_feas(m)) lo = m; else hi = m;
     }
     float t_max = lo;
-    if (t_max <= 0.f) return {0.f, 0.f};
 
-    // Binary search for t_min (lower edge — minimum flight time)
-    lo = 0.f; hi = t_max;
+    // Refine t_min in [global_t_min - dt_sweep, global_t_min]
+    lo = std::max(global_t_min - dt_sweep, tol);
+    hi = global_t_min;
     while (hi - lo > tol) {
         float m = 0.5f * (lo + hi);
         if (is_feas(m)) hi = m; else lo = m;

--- a/deps/turret_planner/src/preposition.cpp
+++ b/deps/turret_planner/src/preposition.cpp
@@ -107,7 +107,7 @@ PrepositionResult preposition_robust_compute(
     float t_available,
     float lambda_decay,
     int   k_samples,
-    float omega_drop,
+    float drop_fraction,
     const TurretWeights& weights,
     const TurretBounds& bounds,
     const PhysicsConfig& cfg,
@@ -132,7 +132,7 @@ PrepositionResult preposition_robust_compute(
                 turret_x, turret_y, turret_z,
                 s.x,  s.y,  target_z,
                 sn.x, sn.y, target_z,
-                robot_vx, robot_vy, omega_drop,
+                robot_vx, robot_vy, drop_fraction,
                 weights, bounds, cfg, omega);
             if (res.feasible) {
                 theta = res.s1.theta;

--- a/deps/turret_planner/src/robust_3shot.cpp
+++ b/deps/turret_planner/src/robust_3shot.cpp
@@ -1,0 +1,501 @@
+#include "turret_planner/robust_3shot.h"
+#include "turret_planner/flight_time.h"
+#include <cmath>
+#include <algorithm>
+#include <queue>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// Interpolate a FutureState at time t from a sorted trajectory array.
+// Linear interpolation between bracketing samples; clamps to endpoints.
+// ---------------------------------------------------------------------------
+static FutureState interp_state(const FutureState* traj, int n, float t) {
+    if (n <= 0) return {};
+    if (t <= traj[0].t || n == 1) return traj[0];
+    if (t >= traj[n-1].t) return traj[n-1];
+
+    // Binary search for bracket
+    int lo = 0, hi = n - 1;
+    while (hi - lo > 1) {
+        int mid = (lo + hi) / 2;
+        if (traj[mid].t <= t) lo = mid; else hi = mid;
+    }
+
+    float dt = traj[hi].t - traj[lo].t;
+    if (dt < 1e-9f) return traj[lo];
+    float frac = (t - traj[lo].t) / dt;
+
+    FutureState s;
+    s.t       = t;
+    s.x       = traj[lo].x  + frac * (traj[hi].x  - traj[lo].x);
+    s.y       = traj[lo].y  + frac * (traj[hi].y  - traj[lo].y);
+    s.heading = traj[lo].heading + frac * (traj[hi].heading - traj[lo].heading);
+    s.vx      = traj[lo].vx + frac * (traj[hi].vx - traj[lo].vx);
+    s.vy      = traj[lo].vy + frac * (traj[hi].vy - traj[lo].vy);
+    return s;
+}
+
+// ---------------------------------------------------------------------------
+// 1-ball solver: sweep trajectory, pick best tau from current state.
+// ---------------------------------------------------------------------------
+static Robust3ShotResult solve_1ball(
+    const FutureState* traj, int n_states,
+    float turret_z,
+    float target_x, float target_y, float target_z,
+    const TurretState& current,
+    float t_min_shot,       // earliest allowed shot time
+    float w_urgency,
+    const TurretWeights& weights,
+    const TurretBounds& bounds,
+    const PhysicsConfig& cfg,
+    const OmegaMapParams& omega,
+    float tol)
+{
+    Robust3ShotResult best{};
+    best.feasible = false;
+    best.J = 1e9f;
+    best.idx1 = best.idx2 = best.idx3 = -1;
+
+    float T_warm = -1.f;
+
+    for (int i = 0; i < n_states; ++i) {
+        if (traj[i].t < t_min_shot) continue;
+        // Ensure trajectory extends far enough
+        if (traj[i].t > traj[n_states-1].t) break;
+
+        FutureState st = traj[i];
+
+        FlightTimeResult res;
+        if (T_warm < 0.f) {
+            res = flight_time_cold(
+                st.x, st.y, turret_z,
+                target_x, target_y, target_z,
+                st.vx, st.vy,
+                current, weights, bounds, cfg, omega, tol);
+        } else {
+            res = flight_time_warm(
+                st.x, st.y, turret_z,
+                target_x, target_y, target_z,
+                st.vx, st.vy, T_warm,
+                current, weights, bounds, cfg, omega);
+        }
+
+        if (!res.feasible) continue;
+        T_warm = res.T_star;
+
+        float cost = w_urgency * res.tau;
+        if (cost < best.J) {
+            best.J = cost;
+            best.feasible = true;
+            best.idx1 = i;
+            best.T1 = res.T_star;
+            best.s1 = res.params;
+        }
+    }
+
+    return best;
+}
+
+// ---------------------------------------------------------------------------
+// N-dimensional B&B helper types
+// ---------------------------------------------------------------------------
+namespace {
+
+// Generic move cost between two shots with drop
+float move_cost(const ShotParams& from, const ShotParams& to,
+                float drop_frac, const TurretWeights& w, const OmegaMapParams& om) {
+    float om_from = omega_map_eval(om, from.phi, from.v_exit) * (1.f - drop_frac);
+    float om_to   = omega_map_eval(om, to.phi, to.v_exit);
+    float d_omega = std::abs(om_from - om_to);
+    float d_phi   = std::abs(from.phi - to.phi);
+    float d_theta = std::abs(from.theta - to.theta);
+    return std::max({w.w_omega * d_omega, w.w_phi * d_phi, w.w_theta * d_theta});
+}
+
+struct Box2D {
+    float t1Lo, t1Hi, t2Lo, t2Hi;
+    float lb;
+};
+
+struct Box2DGreater {
+    bool operator()(const Box2D& a, const Box2D& b) const { return a.lb > b.lb; }
+};
+
+struct Box3D {
+    float t1Lo, t1Hi, t2Lo, t2Hi, t3Lo, t3Hi;
+    float lb;
+};
+
+struct Box3DGreater {
+    bool operator()(const Box3D& a, const Box3D& b) const { return a.lb > b.lb; }
+};
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// 2-ball solver: for each t1 candidate, 2D B&B over (T1, T2).
+// ---------------------------------------------------------------------------
+static Robust3ShotResult solve_2ball(
+    const FutureState* traj, int n_states,
+    float turret_z,
+    float target_x, float target_y, float target_z,
+    const TurretState& current,
+    float t_min_shot, float transfer_time,
+    float drop_fraction, float w_urgency,
+    const TurretWeights& weights,
+    const TurretBounds& bounds,
+    const PhysicsConfig& cfg,
+    const OmegaMapParams& omega,
+    float tol, int maxIter)
+{
+    Robust3ShotResult best{};
+    best.feasible = false;
+    best.J = 1e9f;
+    best.idx1 = best.idx2 = best.idx3 = -1;
+
+    float traj_end = traj[n_states-1].t;
+
+    for (int i = 0; i < n_states; ++i) {
+        float t1 = traj[i].t;
+        if (t1 < t_min_shot) continue;
+        float t2 = t1 + transfer_time;
+        if (t2 > traj_end) break;
+
+        FutureState st1 = traj[i];
+        FutureState st2 = interp_state(traj, n_states, t2);
+
+        float dx1 = target_x - st1.x, dy1 = target_y - st1.y, dz1 = target_z - turret_z;
+        float dx2 = target_x - st2.x, dy2 = target_y - st2.y, dz2 = target_z - turret_z;
+
+        TInterval iv1 = ballistics_feasible_interval(dx1, dy1, dz1, st1.vx, st1.vy, bounds, cfg, tol*0.25f);
+        TInterval iv2 = ballistics_feasible_interval(dx2, dy2, dz2, st2.vx, st2.vy, bounds, cfg, tol*0.25f);
+        if (iv1.t_lo >= iv1.t_hi || iv2.t_lo >= iv2.t_hi) continue;
+
+        // Lipschitz constants
+        LipschitzBounds lip1 = ballistics_lipschitz(dx1, dy1, dz1, st1.vx, st1.vy, iv1.t_lo, iv1.t_hi, cfg);
+        LipschitzBounds lip2 = ballistics_lipschitz(dx2, dy2, dz2, st2.vx, st2.vy, iv2.t_lo, iv2.t_hi, cfg);
+
+        auto lip_omega = [&](const LipschitzBounds& lip, float tx, float ty, float tz,
+                             float vx, float vy, float lo, float hi) -> float {
+            float tmid = 0.5f*(lo+hi), hw = 0.5f*(hi-lo);
+            ShotParams sm = ballistics_solve(0,0,0, tx-0.f, ty-0.f, tz-turret_z, vx, vy, tmid, cfg, omega);
+            return omega_map_lipschitz(omega, sm.phi - lip.l_phi*hw, sm.phi + lip.l_phi*hw,
+                                       sm.v_exit - lip.l_vexit*hw, sm.v_exit + lip.l_vexit*hw,
+                                       lip.l_phi, lip.l_vexit);
+        };
+
+        float lom1 = lip_omega(lip1, target_x, target_y, target_z, st1.vx, st1.vy, iv1.t_lo, iv1.t_hi);
+        float lom2 = lip_omega(lip2, target_x, target_y, target_z, st2.vx, st2.vy, iv2.t_lo, iv2.t_hi);
+
+        // L_T1: from J0 (full omega) + J12 (dropped omega)
+        float L_J0_T1 = w_urgency * std::max({weights.w_theta * lip1.l_theta,
+                                                weights.w_phi * lip1.l_phi,
+                                                weights.w_omega * lom1});
+        float L_J12_T1 = std::max({weights.w_theta * lip1.l_theta,
+                                    weights.w_phi * lip1.l_phi,
+                                    weights.w_omega * (1.f - drop_fraction) * lom1});
+        float L1 = L_J0_T1 + L_J12_T1;
+        float L2 = std::max({weights.w_theta * lip2.l_theta,
+                             weights.w_phi * lip2.l_phi,
+                             weights.w_omega * lom2});
+
+        // Objective
+        auto J = [&](float T1, float T2) -> float {
+            ShotParams s1 = ballistics_solve(st1.x, st1.y, turret_z, target_x, target_y, target_z,
+                                              st1.vx, st1.vy, T1, cfg, omega);
+            ShotParams s2 = ballistics_solve(st2.x, st2.y, turret_z, target_x, target_y, target_z,
+                                              st2.vx, st2.vy, T2, cfg, omega);
+            float j0 = w_urgency * flight_time_tau(s1, current, weights, omega);
+            float j12 = move_cost(s1, s2, drop_fraction, weights, omega);
+            return j0 + j12;
+        };
+
+        // 2D B&B
+        auto make_rect = [&](float t1Lo, float t1Hi, float t2Lo, float t2Hi) -> Box2D {
+            float tc1 = 0.5f*(t1Lo+t1Hi), tc2 = 0.5f*(t2Lo+t2Hi);
+            float lb = J(tc1,tc2) - L1*(t1Hi-t1Lo)*0.5f - L2*(t2Hi-t2Lo)*0.5f;
+            return {t1Lo, t1Hi, t2Lo, t2Hi, lb};
+        };
+
+        float tM1 = 0.5f*(iv1.t_lo+iv1.t_hi), tM2 = 0.5f*(iv2.t_lo+iv2.t_hi);
+        float bestJ_local = J(tM1, tM2);
+        float bestT1 = tM1, bestT2 = tM2;
+        for (float c1 : {iv1.t_lo, iv1.t_hi}) for (float c2 : {iv2.t_lo, iv2.t_hi}) {
+            float j = J(c1, c2);
+            if (j < bestJ_local) { bestJ_local = j; bestT1 = c1; bestT2 = c2; }
+        }
+
+        std::priority_queue<Box2D, std::vector<Box2D>, Box2DGreater> queue;
+        queue.push(make_rect(iv1.t_lo, iv1.t_hi, iv2.t_lo, iv2.t_hi));
+
+        for (int iter = 0; iter < maxIter && !queue.empty(); ++iter) {
+            Box2D r = queue.top(); queue.pop();
+            if (bestJ_local - r.lb <= tol) break;
+
+            float h1 = L1*(r.t1Hi-r.t1Lo)*0.5f;
+            float h2 = L2*(r.t2Hi-r.t2Lo)*0.5f;
+
+            Box2D children[2];
+            if (h1 >= h2) {
+                float tm = 0.5f*(r.t1Lo+r.t1Hi);
+                children[0] = make_rect(r.t1Lo, tm, r.t2Lo, r.t2Hi);
+                children[1] = make_rect(tm, r.t1Hi, r.t2Lo, r.t2Hi);
+            } else {
+                float tm = 0.5f*(r.t2Lo+r.t2Hi);
+                children[0] = make_rect(r.t1Lo, r.t1Hi, r.t2Lo, tm);
+                children[1] = make_rect(r.t1Lo, r.t1Hi, tm, r.t2Hi);
+            }
+
+            for (auto& c : children) {
+                float tc1 = 0.5f*(c.t1Lo+c.t1Hi), tc2 = 0.5f*(c.t2Lo+c.t2Hi);
+                float j = J(tc1, tc2);
+                if (j < bestJ_local) { bestJ_local = j; bestT1 = tc1; bestT2 = tc2; }
+                if (c.lb < bestJ_local) queue.push(c);
+            }
+        }
+
+        if (bestJ_local < best.J) {
+            best.J = bestJ_local;
+            best.feasible = true;
+            best.idx1 = i;
+            best.idx2 = -1; // t2 is deterministic from t1
+            best.T1 = bestT1;
+            best.T2 = bestT2;
+            best.s1 = ballistics_solve(st1.x, st1.y, turret_z, target_x, target_y, target_z,
+                                        st1.vx, st1.vy, bestT1, cfg, omega);
+            best.s2 = ballistics_solve(st2.x, st2.y, turret_z, target_x, target_y, target_z,
+                                        st2.vx, st2.vy, bestT2, cfg, omega);
+        }
+    }
+
+    return best;
+}
+
+// ---------------------------------------------------------------------------
+// 3-ball solver: for each t1 candidate, 3D B&B over (T1, T2, T3).
+// ---------------------------------------------------------------------------
+static Robust3ShotResult solve_3ball(
+    const FutureState* traj, int n_states,
+    float turret_z,
+    float target_x, float target_y, float target_z,
+    const TurretState& current,
+    float t_min_shot, float transfer_time,
+    float drop_fraction, float w_urgency,
+    const TurretWeights& weights,
+    const TurretBounds& bounds,
+    const PhysicsConfig& cfg,
+    const OmegaMapParams& omega,
+    float tol, int maxIter)
+{
+    Robust3ShotResult best{};
+    best.feasible = false;
+    best.J = 1e9f;
+    best.idx1 = best.idx2 = best.idx3 = -1;
+
+    float traj_end = traj[n_states-1].t;
+
+    for (int i = 0; i < n_states; ++i) {
+        float t1 = traj[i].t;
+        if (t1 < t_min_shot) continue;
+        float t2 = t1 + transfer_time;
+        float t3 = t1 + 2.f * transfer_time;
+        if (t3 > traj_end) break;
+
+        FutureState st1 = traj[i];
+        FutureState st2 = interp_state(traj, n_states, t2);
+        FutureState st3 = interp_state(traj, n_states, t3);
+
+        float dx1 = target_x - st1.x, dy1 = target_y - st1.y, dz = target_z - turret_z;
+        float dx2 = target_x - st2.x, dy2 = target_y - st2.y;
+        float dx3 = target_x - st3.x, dy3 = target_y - st3.y;
+
+        TInterval iv1 = ballistics_feasible_interval(dx1, dy1, dz, st1.vx, st1.vy, bounds, cfg, tol*0.25f);
+        TInterval iv2 = ballistics_feasible_interval(dx2, dy2, dz, st2.vx, st2.vy, bounds, cfg, tol*0.25f);
+        TInterval iv3 = ballistics_feasible_interval(dx3, dy3, dz, st3.vx, st3.vy, bounds, cfg, tol*0.25f);
+        if (iv1.t_lo >= iv1.t_hi || iv2.t_lo >= iv2.t_hi || iv3.t_lo >= iv3.t_hi) continue;
+
+        // Lipschitz constants per shot
+        LipschitzBounds lip1 = ballistics_lipschitz(dx1, dy1, dz, st1.vx, st1.vy, iv1.t_lo, iv1.t_hi, cfg);
+        LipschitzBounds lip2 = ballistics_lipschitz(dx2, dy2, dz, st2.vx, st2.vy, iv2.t_lo, iv2.t_hi, cfg);
+        LipschitzBounds lip3 = ballistics_lipschitz(dx3, dy3, dz, st3.vx, st3.vy, iv3.t_lo, iv3.t_hi, cfg);
+
+        auto lip_omega_fn = [&](const LipschitzBounds& lip, float px, float py,
+                                float vx, float vy, float lo, float hi) -> float {
+            float tmid = 0.5f*(lo+hi), hw = 0.5f*(hi-lo);
+            ShotParams sm = ballistics_solve(px, py, turret_z, target_x, target_y, target_z,
+                                              vx, vy, tmid, cfg, omega);
+            return omega_map_lipschitz(omega, sm.phi - lip.l_phi*hw, sm.phi + lip.l_phi*hw,
+                                       sm.v_exit - lip.l_vexit*hw, sm.v_exit + lip.l_vexit*hw,
+                                       lip.l_phi, lip.l_vexit);
+        };
+
+        float lom1 = lip_omega_fn(lip1, st1.x, st1.y, st1.vx, st1.vy, iv1.t_lo, iv1.t_hi);
+        float lom2 = lip_omega_fn(lip2, st2.x, st2.y, st2.vx, st2.vy, iv2.t_lo, iv2.t_hi);
+        float lom3 = lip_omega_fn(lip3, st3.x, st3.y, st3.vx, st3.vy, iv3.t_lo, iv3.t_hi);
+
+        // Separable Lipschitz:
+        // L_T1 = w_urgency * L_J0_T1 + L_J12_T1
+        float L_J0_T1 = w_urgency * std::max({weights.w_theta * lip1.l_theta,
+                                                weights.w_phi * lip1.l_phi,
+                                                weights.w_omega * lom1});
+        float L_J12_T1 = std::max({weights.w_theta * lip1.l_theta,
+                                    weights.w_phi * lip1.l_phi,
+                                    weights.w_omega * (1.f - drop_fraction) * lom1});
+        float L1 = L_J0_T1 + L_J12_T1;
+
+        // L_T2 = L_J12_T2 + L_J23_T2
+        float L_J12_T2 = std::max({weights.w_theta * lip2.l_theta,
+                                    weights.w_phi * lip2.l_phi,
+                                    weights.w_omega * lom2});
+        float L_J23_T2 = std::max({weights.w_theta * lip2.l_theta,
+                                    weights.w_phi * lip2.l_phi,
+                                    weights.w_omega * (1.f - drop_fraction) * lom2});
+        float L2 = L_J12_T2 + L_J23_T2;
+
+        // L_T3 = L_J23_T3 only
+        float L3 = std::max({weights.w_theta * lip3.l_theta,
+                             weights.w_phi * lip3.l_phi,
+                             weights.w_omega * lom3});
+
+        // Objective
+        auto J = [&](float T1, float T2, float T3) -> float {
+            ShotParams s1 = ballistics_solve(st1.x, st1.y, turret_z, target_x, target_y, target_z,
+                                              st1.vx, st1.vy, T1, cfg, omega);
+            ShotParams s2 = ballistics_solve(st2.x, st2.y, turret_z, target_x, target_y, target_z,
+                                              st2.vx, st2.vy, T2, cfg, omega);
+            ShotParams s3 = ballistics_solve(st3.x, st3.y, turret_z, target_x, target_y, target_z,
+                                              st3.vx, st3.vy, T3, cfg, omega);
+            float j0  = w_urgency * flight_time_tau(s1, current, weights, omega);
+            float j12 = move_cost(s1, s2, drop_fraction, weights, omega);
+            float j23 = move_cost(s2, s3, drop_fraction, weights, omega);
+            return j0 + j12 + j23;
+        };
+
+        // Seed from 27 points (3^3 grid)
+        float seeds1[3] = {iv1.t_lo, 0.5f*(iv1.t_lo+iv1.t_hi), iv1.t_hi};
+        float seeds2[3] = {iv2.t_lo, 0.5f*(iv2.t_lo+iv2.t_hi), iv2.t_hi};
+        float seeds3[3] = {iv3.t_lo, 0.5f*(iv3.t_lo+iv3.t_hi), iv3.t_hi};
+
+        float bestJ_local = 1e9f;
+        float bestT1 = seeds1[1], bestT2 = seeds2[1], bestT3 = seeds3[1];
+        for (float c1 : seeds1) for (float c2 : seeds2) for (float c3 : seeds3) {
+            float j = J(c1, c2, c3);
+            if (j < bestJ_local) { bestJ_local = j; bestT1 = c1; bestT2 = c2; bestT3 = c3; }
+        }
+
+        // 3D B&B
+        auto make_box = [&](float lo1, float hi1, float lo2, float hi2, float lo3, float hi3) -> Box3D {
+            float tc1 = 0.5f*(lo1+hi1), tc2 = 0.5f*(lo2+hi2), tc3 = 0.5f*(lo3+hi3);
+            float lb = J(tc1,tc2,tc3) - L1*(hi1-lo1)*0.5f - L2*(hi2-lo2)*0.5f - L3*(hi3-lo3)*0.5f;
+            return {lo1, hi1, lo2, hi2, lo3, hi3, lb};
+        };
+
+        std::priority_queue<Box3D, std::vector<Box3D>, Box3DGreater> queue;
+        queue.push(make_box(iv1.t_lo, iv1.t_hi, iv2.t_lo, iv2.t_hi, iv3.t_lo, iv3.t_hi));
+
+        for (int iter = 0; iter < maxIter && !queue.empty(); ++iter) {
+            Box3D r = queue.top(); queue.pop();
+            if (bestJ_local - r.lb <= tol) break;
+
+            // Bisect dimension with largest Lipschitz-weighted half-width
+            float h1 = L1 * (r.t1Hi - r.t1Lo) * 0.5f;
+            float h2 = L2 * (r.t2Hi - r.t2Lo) * 0.5f;
+            float h3 = L3 * (r.t3Hi - r.t3Lo) * 0.5f;
+
+            Box3D children[2];
+            if (h1 >= h2 && h1 >= h3) {
+                float tm = 0.5f*(r.t1Lo + r.t1Hi);
+                children[0] = make_box(r.t1Lo, tm,     r.t2Lo, r.t2Hi, r.t3Lo, r.t3Hi);
+                children[1] = make_box(tm,     r.t1Hi, r.t2Lo, r.t2Hi, r.t3Lo, r.t3Hi);
+            } else if (h2 >= h1 && h2 >= h3) {
+                float tm = 0.5f*(r.t2Lo + r.t2Hi);
+                children[0] = make_box(r.t1Lo, r.t1Hi, r.t2Lo, tm,     r.t3Lo, r.t3Hi);
+                children[1] = make_box(r.t1Lo, r.t1Hi, tm,     r.t2Hi, r.t3Lo, r.t3Hi);
+            } else {
+                float tm = 0.5f*(r.t3Lo + r.t3Hi);
+                children[0] = make_box(r.t1Lo, r.t1Hi, r.t2Lo, r.t2Hi, r.t3Lo, tm);
+                children[1] = make_box(r.t1Lo, r.t1Hi, r.t2Lo, r.t2Hi, tm,     r.t3Hi);
+            }
+
+            for (auto& c : children) {
+                float tc1 = 0.5f*(c.t1Lo+c.t1Hi), tc2 = 0.5f*(c.t2Lo+c.t2Hi), tc3 = 0.5f*(c.t3Lo+c.t3Hi);
+                float j = J(tc1, tc2, tc3);
+                if (j < bestJ_local) { bestJ_local = j; bestT1 = tc1; bestT2 = tc2; bestT3 = tc3; }
+                if (c.lb < bestJ_local) queue.push(c);
+            }
+        }
+
+        if (bestJ_local < best.J) {
+            best.J = bestJ_local;
+            best.feasible = true;
+            best.idx1 = i;
+            best.idx2 = -1;
+            best.idx3 = -1;
+            best.T1 = bestT1; best.T2 = bestT2; best.T3 = bestT3;
+            best.s1 = ballistics_solve(st1.x, st1.y, turret_z, target_x, target_y, target_z,
+                                        st1.vx, st1.vy, bestT1, cfg, omega);
+            best.s2 = ballistics_solve(st2.x, st2.y, turret_z, target_x, target_y, target_z,
+                                        st2.vx, st2.vy, bestT2, cfg, omega);
+            best.s3 = ballistics_solve(st3.x, st3.y, turret_z, target_x, target_y, target_z,
+                                        st3.vx, st3.vy, bestT3, cfg, omega);
+        }
+    }
+
+    return best;
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+Robust3ShotResult robust_3shot_plan(
+    const FutureState* trajectory, int n_states,
+    float turret_z,
+    float target_x, float target_y, float target_z,
+    const TurretState& current,
+    int   n_balls,
+    float t_remaining,
+    float transfer_time,
+    float drop_fraction,
+    float urgency_lambda,
+    const TurretWeights& weights,
+    const TurretBounds& bounds,
+    const PhysicsConfig& cfg,
+    const OmegaMapParams& omega,
+    float tol,
+    int   maxIter)
+{
+    if (n_states <= 0 || n_balls <= 0) {
+        Robust3ShotResult r{};
+        r.feasible = false;
+        r.J = 1e9f;
+        r.idx1 = r.idx2 = r.idx3 = -1;
+        return r;
+    }
+
+    float w_urgency = std::exp(-urgency_lambda * t_remaining);
+    // t_remaining is the time until the next ball can exit the shooter.
+    // The solver uses this directly as the earliest shot time on the trajectory.
+    float t_min_shot = t_remaining;
+
+    n_balls = std::clamp(n_balls, 1, 3);
+
+    if (n_balls == 1) {
+        return solve_1ball(trajectory, n_states, turret_z,
+                           target_x, target_y, target_z,
+                           current, t_min_shot, w_urgency,
+                           weights, bounds, cfg, omega, tol);
+    } else if (n_balls == 2) {
+        return solve_2ball(trajectory, n_states, turret_z,
+                           target_x, target_y, target_z,
+                           current, t_min_shot, transfer_time,
+                           drop_fraction, w_urgency,
+                           weights, bounds, cfg, omega, tol, maxIter);
+    } else {
+        return solve_3ball(trajectory, n_states, turret_z,
+                           target_x, target_y, target_z,
+                           current, t_min_shot, transfer_time,
+                           drop_fraction, w_urgency,
+                           weights, bounds, cfg, omega, tol, maxIter);
+    }
+}

--- a/deps/turret_planner/src/robust_3shot.cpp
+++ b/deps/turret_planner/src/robust_3shot.cpp
@@ -7,14 +7,12 @@
 
 // ---------------------------------------------------------------------------
 // Interpolate a FutureState at time t from a sorted trajectory array.
-// Linear interpolation between bracketing samples; clamps to endpoints.
 // ---------------------------------------------------------------------------
 static FutureState interp_state(const FutureState* traj, int n, float t) {
     if (n <= 0) return {};
     if (t <= traj[0].t || n == 1) return traj[0];
     if (t >= traj[n-1].t) return traj[n-1];
 
-    // Binary search for bracket
     int lo = 0, hi = n - 1;
     while (hi - lo > 1) {
         int mid = (lo + hi) / 2;
@@ -36,6 +34,50 @@ static FutureState interp_state(const FutureState* traj, int n, float t) {
 }
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Check that a shot's launch direction is within 90° of the geometric
+// direction from the turret to the target.  When the robot's velocity
+// dominates dx/T, atan2 can flip theta ~180° — the ball still reaches the
+// target (carried by the robot's momentum) but the turret points away from
+// the goal, which is impractical.
+static bool is_forward_shot(const ShotParams& p, float dx, float dy) {
+    // Positive dot product with target direction => launch is toward the goal.
+    return std::cos(p.theta) * dx + std::sin(p.theta) * dy > 0.f;
+}
+
+namespace {
+
+float move_cost(const ShotParams& from, const ShotParams& to,
+                float drop_frac, const TurretWeights& w, const OmegaMapParams& om) {
+    float om_from = omega_map_eval(om, from.phi, from.v_exit) * (1.f - drop_frac);
+    float om_to   = omega_map_eval(om, to.phi, to.v_exit);
+    float d_omega = std::abs(om_from - om_to);
+    float d_phi   = std::abs(from.phi - to.phi);
+    float d_theta = std::abs(from.theta - to.theta);
+    return std::max({w.w_omega * d_omega, w.w_phi * d_phi, w.w_theta * d_theta});
+}
+
+struct Box2D {
+    float t1Lo, t1Hi, t2Lo, t2Hi;
+    float lb;
+};
+struct Box2DGreater {
+    bool operator()(const Box2D& a, const Box2D& b) const { return a.lb > b.lb; }
+};
+
+struct Box3D {
+    float t1Lo, t1Hi, t2Lo, t2Hi, t3Lo, t3Hi;
+    float lb;
+};
+struct Box3DGreater {
+    bool operator()(const Box3D& a, const Box3D& b) const { return a.lb > b.lb; }
+};
+
+} // namespace
+
+// ---------------------------------------------------------------------------
 // 1-ball solver: sweep trajectory, pick best tau from current state.
 // ---------------------------------------------------------------------------
 static Robust3ShotResult solve_1ball(
@@ -43,8 +85,7 @@ static Robust3ShotResult solve_1ball(
     float turret_z,
     float target_x, float target_y, float target_z,
     const TurretState& current,
-    float t_min_shot,       // earliest allowed shot time
-    float w_urgency,
+    float t_min_shot,
     const TurretWeights& weights,
     const TurretBounds& bounds,
     const PhysicsConfig& cfg,
@@ -54,14 +95,13 @@ static Robust3ShotResult solve_1ball(
     Robust3ShotResult best{};
     best.feasible = false;
     best.J = 1e9f;
+    best.J_12 = best.J_23 = 0.f;
     best.idx1 = best.idx2 = best.idx3 = -1;
 
     float T_warm = -1.f;
 
     for (int i = 0; i < n_states; ++i) {
         if (traj[i].t < t_min_shot) continue;
-        // Ensure trajectory extends far enough
-        if (traj[i].t > traj[n_states-1].t) break;
 
         FutureState st = traj[i];
 
@@ -81,9 +121,17 @@ static Robust3ShotResult solve_1ball(
         }
 
         if (!res.feasible) continue;
+
+        // Reject solutions where the turret points away from the goal.
+        float dx = target_x - st.x, dy = target_y - st.y;
+        if (!is_forward_shot(res.params, dx, dy)) continue;
+
+        // Only warm-start from forward solutions — a backward T biases
+        // flight_time_warm toward backward local minima at all subsequent
+        // trajectory points.
         T_warm = res.T_star;
 
-        float cost = w_urgency * res.tau;
+        float cost = res.tau;  // J_0 only
         if (cost < best.J) {
             best.J = cost;
             best.feasible = true;
@@ -97,43 +145,8 @@ static Robust3ShotResult solve_1ball(
 }
 
 // ---------------------------------------------------------------------------
-// N-dimensional B&B helper types
-// ---------------------------------------------------------------------------
-namespace {
-
-// Generic move cost between two shots with drop
-float move_cost(const ShotParams& from, const ShotParams& to,
-                float drop_frac, const TurretWeights& w, const OmegaMapParams& om) {
-    float om_from = omega_map_eval(om, from.phi, from.v_exit) * (1.f - drop_frac);
-    float om_to   = omega_map_eval(om, to.phi, to.v_exit);
-    float d_omega = std::abs(om_from - om_to);
-    float d_phi   = std::abs(from.phi - to.phi);
-    float d_theta = std::abs(from.theta - to.theta);
-    return std::max({w.w_omega * d_omega, w.w_phi * d_phi, w.w_theta * d_theta});
-}
-
-struct Box2D {
-    float t1Lo, t1Hi, t2Lo, t2Hi;
-    float lb;
-};
-
-struct Box2DGreater {
-    bool operator()(const Box2D& a, const Box2D& b) const { return a.lb > b.lb; }
-};
-
-struct Box3D {
-    float t1Lo, t1Hi, t2Lo, t2Hi, t3Lo, t3Hi;
-    float lb;
-};
-
-struct Box3DGreater {
-    bool operator()(const Box3D& a, const Box3D& b) const { return a.lb > b.lb; }
-};
-
-} // namespace
-
-// ---------------------------------------------------------------------------
-// 2-ball solver: for each t1 candidate, 2D B&B over (T1, T2).
+// 2-ball solver: for each t1, 2D B&B over (T1, T2).
+// Objective: J_0 + J_12, constraint: J_12 <= transfer_time
 // ---------------------------------------------------------------------------
 static Robust3ShotResult solve_2ball(
     const FutureState* traj, int n_states,
@@ -141,7 +154,7 @@ static Robust3ShotResult solve_2ball(
     float target_x, float target_y, float target_z,
     const TurretState& current,
     float t_min_shot, float transfer_time,
-    float drop_fraction, float w_urgency,
+    float drop_fraction,
     const TurretWeights& weights,
     const TurretBounds& bounds,
     const PhysicsConfig& cfg,
@@ -151,6 +164,7 @@ static Robust3ShotResult solve_2ball(
     Robust3ShotResult best{};
     best.feasible = false;
     best.J = 1e9f;
+    best.J_12 = best.J_23 = 0.f;
     best.idx1 = best.idx2 = best.idx3 = -1;
 
     float traj_end = traj[n_states-1].t;
@@ -164,57 +178,54 @@ static Robust3ShotResult solve_2ball(
         FutureState st1 = traj[i];
         FutureState st2 = interp_state(traj, n_states, t2);
 
-        float dx1 = target_x - st1.x, dy1 = target_y - st1.y, dz1 = target_z - turret_z;
-        float dx2 = target_x - st2.x, dy2 = target_y - st2.y, dz2 = target_z - turret_z;
+        float dx1 = target_x - st1.x, dy1 = target_y - st1.y, dz = target_z - turret_z;
+        float dx2 = target_x - st2.x, dy2 = target_y - st2.y;
 
-        TInterval iv1 = ballistics_feasible_interval(dx1, dy1, dz1, st1.vx, st1.vy, bounds, cfg, tol*0.25f);
-        TInterval iv2 = ballistics_feasible_interval(dx2, dy2, dz2, st2.vx, st2.vy, bounds, cfg, tol*0.25f);
+        TInterval iv1 = ballistics_feasible_interval(dx1, dy1, dz, st1.vx, st1.vy, bounds, cfg, tol*0.25f);
+        TInterval iv2 = ballistics_feasible_interval(dx2, dy2, dz, st2.vx, st2.vy, bounds, cfg, tol*0.25f);
         if (iv1.t_lo >= iv1.t_hi || iv2.t_lo >= iv2.t_hi) continue;
 
         // Lipschitz constants
-        LipschitzBounds lip1 = ballistics_lipschitz(dx1, dy1, dz1, st1.vx, st1.vy, iv1.t_lo, iv1.t_hi, cfg);
-        LipschitzBounds lip2 = ballistics_lipschitz(dx2, dy2, dz2, st2.vx, st2.vy, iv2.t_lo, iv2.t_hi, cfg);
+        LipschitzBounds lip1 = ballistics_lipschitz(dx1, dy1, dz, st1.vx, st1.vy, iv1.t_lo, iv1.t_hi, cfg);
+        LipschitzBounds lip2 = ballistics_lipschitz(dx2, dy2, dz, st2.vx, st2.vy, iv2.t_lo, iv2.t_hi, cfg);
 
-        auto lip_omega = [&](const LipschitzBounds& lip, float tx, float ty, float tz,
-                             float vx, float vy, float lo, float hi) -> float {
+        auto lip_omega_fn = [&](const LipschitzBounds& lip, float px, float py,
+                                float vx, float vy, float lo, float hi) -> float {
             float tmid = 0.5f*(lo+hi), hw = 0.5f*(hi-lo);
-            ShotParams sm = ballistics_solve(0,0,0, tx-0.f, ty-0.f, tz-turret_z, vx, vy, tmid, cfg, omega);
+            ShotParams sm = ballistics_solve(px, py, turret_z, target_x, target_y, target_z,
+                                              vx, vy, tmid, cfg, omega);
             return omega_map_lipschitz(omega, sm.phi - lip.l_phi*hw, sm.phi + lip.l_phi*hw,
                                        sm.v_exit - lip.l_vexit*hw, sm.v_exit + lip.l_vexit*hw,
                                        lip.l_phi, lip.l_vexit);
         };
 
-        float lom1 = lip_omega(lip1, target_x, target_y, target_z, st1.vx, st1.vy, iv1.t_lo, iv1.t_hi);
-        float lom2 = lip_omega(lip2, target_x, target_y, target_z, st2.vx, st2.vy, iv2.t_lo, iv2.t_hi);
+        float lom1 = lip_omega_fn(lip1, st1.x, st1.y, st1.vx, st1.vy, iv1.t_lo, iv1.t_hi);
+        float lom2 = lip_omega_fn(lip2, st2.x, st2.y, st2.vx, st2.vy, iv2.t_lo, iv2.t_hi);
 
-        // L_T1: from J0 (full omega) + J12 (dropped omega)
-        float L_J0_T1 = w_urgency * std::max({weights.w_theta * lip1.l_theta,
-                                                weights.w_phi * lip1.l_phi,
-                                                weights.w_omega * lom1});
-        float L_J12_T1 = std::max({weights.w_theta * lip1.l_theta,
-                                    weights.w_phi * lip1.l_phi,
-                                    weights.w_omega * (1.f - drop_fraction) * lom1});
+        // J_0 depends on T1, J_12 depends on T1 and T2
+        float L_J0_T1  = std::max({weights.w_theta * lip1.l_theta, weights.w_phi * lip1.l_phi, weights.w_omega * lom1});
+        float L_J12_T1 = std::max({weights.w_theta * lip1.l_theta, weights.w_phi * lip1.l_phi, weights.w_omega * (1.f - drop_fraction) * lom1});
         float L1 = L_J0_T1 + L_J12_T1;
-        float L2 = std::max({weights.w_theta * lip2.l_theta,
-                             weights.w_phi * lip2.l_phi,
-                             weights.w_omega * lom2});
+        float L2 = std::max({weights.w_theta * lip2.l_theta, weights.w_phi * lip2.l_phi, weights.w_omega * lom2});
 
-        // Objective
+        // Objective with constraint
         auto J = [&](float T1, float T2) -> float {
             ShotParams s1 = ballistics_solve(st1.x, st1.y, turret_z, target_x, target_y, target_z,
                                               st1.vx, st1.vy, T1, cfg, omega);
             ShotParams s2 = ballistics_solve(st2.x, st2.y, turret_z, target_x, target_y, target_z,
                                               st2.vx, st2.vy, T2, cfg, omega);
-            float j0 = w_urgency * flight_time_tau(s1, current, weights, omega);
+            float j0  = flight_time_tau(s1, current, weights, omega);
             float j12 = move_cost(s1, s2, drop_fraction, weights, omega);
+            // Constraint: J_12 must be achievable within transfer_time
+            if (j12 > transfer_time) return 1e9f;
             return j0 + j12;
         };
 
         // 2D B&B
-        auto make_rect = [&](float t1Lo, float t1Hi, float t2Lo, float t2Hi) -> Box2D {
-            float tc1 = 0.5f*(t1Lo+t1Hi), tc2 = 0.5f*(t2Lo+t2Hi);
-            float lb = J(tc1,tc2) - L1*(t1Hi-t1Lo)*0.5f - L2*(t2Hi-t2Lo)*0.5f;
-            return {t1Lo, t1Hi, t2Lo, t2Hi, lb};
+        auto make_rect = [&](float lo1, float hi1, float lo2, float hi2) -> Box2D {
+            float tc1 = 0.5f*(lo1+hi1), tc2 = 0.5f*(lo2+hi2);
+            float lb = J(tc1, tc2) - L1*(hi1-lo1)*0.5f - L2*(hi2-lo2)*0.5f;
+            return {lo1, hi1, lo2, hi2, lb};
         };
 
         float tM1 = 0.5f*(iv1.t_lo+iv1.t_hi), tM2 = 0.5f*(iv2.t_lo+iv2.t_hi);
@@ -234,7 +245,6 @@ static Robust3ShotResult solve_2ball(
 
             float h1 = L1*(r.t1Hi-r.t1Lo)*0.5f;
             float h2 = L2*(r.t2Hi-r.t2Lo)*0.5f;
-
             Box2D children[2];
             if (h1 >= h2) {
                 float tm = 0.5f*(r.t1Lo+r.t1Hi);
@@ -245,7 +255,6 @@ static Robust3ShotResult solve_2ball(
                 children[0] = make_rect(r.t1Lo, r.t1Hi, r.t2Lo, tm);
                 children[1] = make_rect(r.t1Lo, r.t1Hi, tm, r.t2Hi);
             }
-
             for (auto& c : children) {
                 float tc1 = 0.5f*(c.t1Lo+c.t1Hi), tc2 = 0.5f*(c.t2Lo+c.t2Hi);
                 float j = J(tc1, tc2);
@@ -255,16 +264,23 @@ static Robust3ShotResult solve_2ball(
         }
 
         if (bestJ_local < best.J) {
-            best.J = bestJ_local;
-            best.feasible = true;
-            best.idx1 = i;
-            best.idx2 = -1; // t2 is deterministic from t1
-            best.T1 = bestT1;
-            best.T2 = bestT2;
-            best.s1 = ballistics_solve(st1.x, st1.y, turret_z, target_x, target_y, target_z,
-                                        st1.vx, st1.vy, bestT1, cfg, omega);
-            best.s2 = ballistics_solve(st2.x, st2.y, turret_z, target_x, target_y, target_z,
-                                        st2.vx, st2.vy, bestT2, cfg, omega);
+            ShotParams s1f = ballistics_solve(st1.x, st1.y, turret_z, target_x, target_y, target_z,
+                                               st1.vx, st1.vy, bestT1, cfg, omega);
+            ShotParams s2f = ballistics_solve(st2.x, st2.y, turret_z, target_x, target_y, target_z,
+                                               st2.vx, st2.vy, bestT2, cfg, omega);
+            // Reject if either shot points away from the goal.
+            if (!is_forward_shot(s1f, dx1, dy1) || !is_forward_shot(s2f, dx2, dy2))
+                continue;
+            float j12 = move_cost(s1f, s2f, drop_fraction, weights, omega);
+            if (j12 <= transfer_time) {
+                best.J = bestJ_local;
+                best.J_12 = j12;
+                best.feasible = true;
+                best.idx1 = i;
+                best.idx2 = -1;
+                best.T1 = bestT1; best.T2 = bestT2;
+                best.s1 = s1f; best.s2 = s2f;
+            }
         }
     }
 
@@ -272,7 +288,8 @@ static Robust3ShotResult solve_2ball(
 }
 
 // ---------------------------------------------------------------------------
-// 3-ball solver: for each t1 candidate, 3D B&B over (T1, T2, T3).
+// 3-ball solver: for each t1, 3D B&B over (T1, T2, T3).
+// Objective: J_0 + J_12 + J_23, constraints: J_12 <= tt, J_23 <= tt
 // ---------------------------------------------------------------------------
 static Robust3ShotResult solve_3ball(
     const FutureState* traj, int n_states,
@@ -280,7 +297,7 @@ static Robust3ShotResult solve_3ball(
     float target_x, float target_y, float target_z,
     const TurretState& current,
     float t_min_shot, float transfer_time,
-    float drop_fraction, float w_urgency,
+    float drop_fraction,
     const TurretWeights& weights,
     const TurretBounds& bounds,
     const PhysicsConfig& cfg,
@@ -290,6 +307,7 @@ static Robust3ShotResult solve_3ball(
     Robust3ShotResult best{};
     best.feasible = false;
     best.J = 1e9f;
+    best.J_12 = best.J_23 = 0.f;
     best.idx1 = best.idx2 = best.idx3 = -1;
 
     float traj_end = traj[n_states-1].t;
@@ -314,7 +332,6 @@ static Robust3ShotResult solve_3ball(
         TInterval iv3 = ballistics_feasible_interval(dx3, dy3, dz, st3.vx, st3.vy, bounds, cfg, tol*0.25f);
         if (iv1.t_lo >= iv1.t_hi || iv2.t_lo >= iv2.t_hi || iv3.t_lo >= iv3.t_hi) continue;
 
-        // Lipschitz constants per shot
         LipschitzBounds lip1 = ballistics_lipschitz(dx1, dy1, dz, st1.vx, st1.vy, iv1.t_lo, iv1.t_hi, cfg);
         LipschitzBounds lip2 = ballistics_lipschitz(dx2, dy2, dz, st2.vx, st2.vy, iv2.t_lo, iv2.t_hi, cfg);
         LipschitzBounds lip3 = ballistics_lipschitz(dx3, dy3, dz, st3.vx, st3.vy, iv3.t_lo, iv3.t_hi, cfg);
@@ -333,31 +350,18 @@ static Robust3ShotResult solve_3ball(
         float lom2 = lip_omega_fn(lip2, st2.x, st2.y, st2.vx, st2.vy, iv2.t_lo, iv2.t_hi);
         float lom3 = lip_omega_fn(lip3, st3.x, st3.y, st3.vx, st3.vy, iv3.t_lo, iv3.t_hi);
 
-        // Separable Lipschitz:
-        // L_T1 = w_urgency * L_J0_T1 + L_J12_T1
-        float L_J0_T1 = w_urgency * std::max({weights.w_theta * lip1.l_theta,
-                                                weights.w_phi * lip1.l_phi,
-                                                weights.w_omega * lom1});
-        float L_J12_T1 = std::max({weights.w_theta * lip1.l_theta,
-                                    weights.w_phi * lip1.l_phi,
-                                    weights.w_omega * (1.f - drop_fraction) * lom1});
+        // Separable Lipschitz: J = J_0(T1) + J_12(T1,T2) + J_23(T2,T3)
+        float L_J0_T1  = std::max({weights.w_theta * lip1.l_theta, weights.w_phi * lip1.l_phi, weights.w_omega * lom1});
+        float L_J12_T1 = std::max({weights.w_theta * lip1.l_theta, weights.w_phi * lip1.l_phi, weights.w_omega * (1.f - drop_fraction) * lom1});
         float L1 = L_J0_T1 + L_J12_T1;
 
-        // L_T2 = L_J12_T2 + L_J23_T2
-        float L_J12_T2 = std::max({weights.w_theta * lip2.l_theta,
-                                    weights.w_phi * lip2.l_phi,
-                                    weights.w_omega * lom2});
-        float L_J23_T2 = std::max({weights.w_theta * lip2.l_theta,
-                                    weights.w_phi * lip2.l_phi,
-                                    weights.w_omega * (1.f - drop_fraction) * lom2});
+        float L_J12_T2 = std::max({weights.w_theta * lip2.l_theta, weights.w_phi * lip2.l_phi, weights.w_omega * lom2});
+        float L_J23_T2 = std::max({weights.w_theta * lip2.l_theta, weights.w_phi * lip2.l_phi, weights.w_omega * (1.f - drop_fraction) * lom2});
         float L2 = L_J12_T2 + L_J23_T2;
 
-        // L_T3 = L_J23_T3 only
-        float L3 = std::max({weights.w_theta * lip3.l_theta,
-                             weights.w_phi * lip3.l_phi,
-                             weights.w_omega * lom3});
+        float L3 = std::max({weights.w_theta * lip3.l_theta, weights.w_phi * lip3.l_phi, weights.w_omega * lom3});
 
-        // Objective
+        // Objective with constraints
         auto J = [&](float T1, float T2, float T3) -> float {
             ShotParams s1 = ballistics_solve(st1.x, st1.y, turret_z, target_x, target_y, target_z,
                                               st1.vx, st1.vy, T1, cfg, omega);
@@ -365,13 +369,15 @@ static Robust3ShotResult solve_3ball(
                                               st2.vx, st2.vy, T2, cfg, omega);
             ShotParams s3 = ballistics_solve(st3.x, st3.y, turret_z, target_x, target_y, target_z,
                                               st3.vx, st3.vy, T3, cfg, omega);
-            float j0  = w_urgency * flight_time_tau(s1, current, weights, omega);
+            float j0  = flight_time_tau(s1, current, weights, omega);
             float j12 = move_cost(s1, s2, drop_fraction, weights, omega);
             float j23 = move_cost(s2, s3, drop_fraction, weights, omega);
+            // Hard constraints: transitions must fit within transfer_time
+            if (j12 > transfer_time || j23 > transfer_time) return 1e9f;
             return j0 + j12 + j23;
         };
 
-        // Seed from 27 points (3^3 grid)
+        // Seed from 27 points
         float seeds1[3] = {iv1.t_lo, 0.5f*(iv1.t_lo+iv1.t_hi), iv1.t_hi};
         float seeds2[3] = {iv2.t_lo, 0.5f*(iv2.t_lo+iv2.t_hi), iv2.t_hi};
         float seeds3[3] = {iv3.t_lo, 0.5f*(iv3.t_lo+iv3.t_hi), iv3.t_hi};
@@ -397,7 +403,6 @@ static Robust3ShotResult solve_3ball(
             Box3D r = queue.top(); queue.pop();
             if (bestJ_local - r.lb <= tol) break;
 
-            // Bisect dimension with largest Lipschitz-weighted half-width
             float h1 = L1 * (r.t1Hi - r.t1Lo) * 0.5f;
             float h2 = L2 * (r.t2Hi - r.t2Lo) * 0.5f;
             float h3 = L3 * (r.t3Hi - r.t3Lo) * 0.5f;
@@ -426,18 +431,27 @@ static Robust3ShotResult solve_3ball(
         }
 
         if (bestJ_local < best.J) {
-            best.J = bestJ_local;
-            best.feasible = true;
-            best.idx1 = i;
-            best.idx2 = -1;
-            best.idx3 = -1;
-            best.T1 = bestT1; best.T2 = bestT2; best.T3 = bestT3;
-            best.s1 = ballistics_solve(st1.x, st1.y, turret_z, target_x, target_y, target_z,
-                                        st1.vx, st1.vy, bestT1, cfg, omega);
-            best.s2 = ballistics_solve(st2.x, st2.y, turret_z, target_x, target_y, target_z,
-                                        st2.vx, st2.vy, bestT2, cfg, omega);
-            best.s3 = ballistics_solve(st3.x, st3.y, turret_z, target_x, target_y, target_z,
-                                        st3.vx, st3.vy, bestT3, cfg, omega);
+            ShotParams s1f = ballistics_solve(st1.x, st1.y, turret_z, target_x, target_y, target_z,
+                                               st1.vx, st1.vy, bestT1, cfg, omega);
+            ShotParams s2f = ballistics_solve(st2.x, st2.y, turret_z, target_x, target_y, target_z,
+                                               st2.vx, st2.vy, bestT2, cfg, omega);
+            ShotParams s3f = ballistics_solve(st3.x, st3.y, turret_z, target_x, target_y, target_z,
+                                               st3.vx, st3.vy, bestT3, cfg, omega);
+            // Reject if any shot points away from the goal.
+            if (!is_forward_shot(s1f, dx1, dy1) ||
+                !is_forward_shot(s2f, dx2, dy2) ||
+                !is_forward_shot(s3f, dx3, dy3))
+                continue;
+            float j12 = move_cost(s1f, s2f, drop_fraction, weights, omega);
+            float j23 = move_cost(s2f, s3f, drop_fraction, weights, omega);
+            if (j12 <= transfer_time && j23 <= transfer_time) {
+                best.J = bestJ_local;
+                best.J_12 = j12; best.J_23 = j23;
+                best.feasible = true;
+                best.idx1 = i; best.idx2 = -1; best.idx3 = -1;
+                best.T1 = bestT1; best.T2 = bestT2; best.T3 = bestT3;
+                best.s1 = s1f; best.s2 = s2f; best.s3 = s3f;
+            }
         }
     }
 
@@ -447,7 +461,6 @@ static Robust3ShotResult solve_3ball(
 // ---------------------------------------------------------------------------
 // Public entry point
 // ---------------------------------------------------------------------------
-
 Robust3ShotResult robust_3shot_plan(
     const FutureState* trajectory, int n_states,
     float turret_z,
@@ -457,7 +470,6 @@ Robust3ShotResult robust_3shot_plan(
     float t_remaining,
     float transfer_time,
     float drop_fraction,
-    float urgency_lambda,
     const TurretWeights& weights,
     const TurretBounds& bounds,
     const PhysicsConfig& cfg,
@@ -473,29 +485,25 @@ Robust3ShotResult robust_3shot_plan(
         return r;
     }
 
-    float w_urgency = std::exp(-urgency_lambda * t_remaining);
-    // t_remaining is the time until the next ball can exit the shooter.
-    // The solver uses this directly as the earliest shot time on the trajectory.
     float t_min_shot = t_remaining;
-
     n_balls = std::clamp(n_balls, 1, 3);
 
     if (n_balls == 1) {
         return solve_1ball(trajectory, n_states, turret_z,
                            target_x, target_y, target_z,
-                           current, t_min_shot, w_urgency,
+                           current, t_min_shot,
                            weights, bounds, cfg, omega, tol);
     } else if (n_balls == 2) {
         return solve_2ball(trajectory, n_states, turret_z,
                            target_x, target_y, target_z,
                            current, t_min_shot, transfer_time,
-                           drop_fraction, w_urgency,
+                           drop_fraction,
                            weights, bounds, cfg, omega, tol, maxIter);
     } else {
         return solve_3ball(trajectory, n_states, turret_z,
                            target_x, target_y, target_z,
                            current, t_min_shot, transfer_time,
-                           drop_fraction, w_urgency,
+                           drop_fraction,
                            weights, bounds, cfg, omega, tol, maxIter);
     }
 }

--- a/deps/turret_planner/src/robust_shot.cpp
+++ b/deps/turret_planner/src/robust_shot.cpp
@@ -8,7 +8,7 @@
 // ---------------------------------------------------------------------------
 // 2D Lipschitz branch-and-bound port of Kotlin ShotSolver.optimalRobustShot.
 //
-// The objective is the move cost from (s1 with flywheel reduced by omega_drop)
+// The objective is the move cost from (s1 with flywheel scaled by 1-drop_fraction)
 // to s2. Constants L1, L2 are computed once over the full feasible rectangle;
 // subtracting a constant from one omega doesn't change the Lipschitz constant
 // of the absolute difference.
@@ -33,7 +33,7 @@ RobustShotResult flight_time_robust(
     float target1_x, float target1_y, float target1_z,
     float target2_x, float target2_y, float target2_z,
     float robot_vx, float robot_vy,
-    float omega_drop,
+    float drop_fraction,
     const TurretWeights& weights,
     const TurretBounds&  bounds,
     const PhysicsConfig& cfg,
@@ -61,9 +61,9 @@ RobustShotResult flight_time_robust(
     }
 
     // --- Lipschitz constants on the full rectangle ---
-    auto compute_L = [&](float dx, float dy, float dz,
-                         float tx, float ty, float tz,
-                         float t_lo, float t_hi) -> float {
+    auto compute_L_raw = [&](float dx, float dy, float dz,
+                             float tx, float ty, float tz,
+                             float t_lo, float t_hi) -> std::pair<float, float> {
         LipschitzBounds lip = ballistics_lipschitz(dx, dy, dz, robot_vx, robot_vy,
                                                    t_lo, t_hi, cfg);
         float t_mid = 0.5f * (t_lo + t_hi);
@@ -77,13 +77,17 @@ RobustShotResult flight_time_robust(
         float v_hi   = s_mid.v_exit + lip.l_vexit * hw;
         float l_om = omega_map_lipschitz(omega, phi_lo, phi_hi, v_lo, v_hi,
                                          lip.l_phi, lip.l_vexit);
-        return std::max({weights.w_theta * lip.l_theta,
-                         weights.w_phi   * lip.l_phi,
-                         weights.w_omega * l_om});
+        float l_geom = std::max(weights.w_theta * lip.l_theta,
+                                weights.w_phi   * lip.l_phi);
+        return {l_geom, l_om};
     };
 
-    float L1 = compute_L(dx1, dy1, dz1, target1_x, target1_y, target1_z, iv1.t_lo, iv1.t_hi);
-    float L2 = compute_L(dx2, dy2, dz2, target2_x, target2_y, target2_z, iv2.t_lo, iv2.t_hi);
+    // L1: omega1 is scaled by (1-drop_fraction), so its Lipschitz constant scales too
+    auto [l1_geom, l1_om] = compute_L_raw(dx1, dy1, dz1, target1_x, target1_y, target1_z, iv1.t_lo, iv1.t_hi);
+    float L1 = std::max(l1_geom, weights.w_omega * (1.f - drop_fraction) * l1_om);
+    // L2: omega2 is unscaled
+    auto [l2_geom, l2_om] = compute_L_raw(dx2, dy2, dz2, target2_x, target2_y, target2_z, iv2.t_lo, iv2.t_hi);
+    float L2 = std::max(l2_geom, weights.w_omega * l2_om);
 
     // --- Objective ---
     auto J = [&](float t1, float t2, ShotParams* out_s1 = nullptr,
@@ -94,7 +98,7 @@ RobustShotResult flight_time_robust(
         ShotParams s2 = ballistics_solve(turret_x, turret_y, turret_z,
                                          target2_x, target2_y, target2_z,
                                          robot_vx, robot_vy, t2, cfg, omega);
-        float om1 = omega_map_eval(omega, s1.phi, s1.v_exit) - omega_drop;
+        float om1 = omega_map_eval(omega, s1.phi, s1.v_exit) * (1.f - drop_fraction);
         float om2 = omega_map_eval(omega, s2.phi, s2.v_exit);
         float d_omega = std::abs(om1 - om2);
         float d_phi   = std::abs(s1.phi   - s2.phi);
@@ -192,13 +196,12 @@ RobustShotResult flight_time_robust(
 //     J(T1, T2) = J_Δ(cur → s1(T1)) + J_Δ(s1(T1)_reduced → s2(T2))
 //
 // Lipschitz analysis:
-//   - Term A = J_Δ(cur, s1) depends only on T1; its Lipschitz constant in T1
-//     is the same as the cold solver's compute_L on target1.
-//   - Term B = J_Δ(s1_reduced, s2) depends on both T1 and T2; per-arm
-//     Lipschitz is L_T1 in T1 and L_T2 in T2 (constant omega_drop doesn't
-//     change |Δω|'s Lipschitz constant).
-//   So L1 = L_T1 + L_T1 = 2·L_T1 (A and B both contribute in T1),
-//      L2 = L_T2           (only B contributes in T2).
+//   - Term A = J_Δ(cur, s1) depends only on T1.
+//   - Term B = J_Δ(s1_reduced, s2) depends on both T1 and T2; the
+//     proportional drop (1-drop_fraction) scales the omega Lipschitz
+//     constant in B's T1 arm.
+//   So L1 = L_A + L_B_T1 (A and B both contribute in T1),
+//      L2 = L_B_T2        (only B contributes in T2).
 // ---------------------------------------------------------------------------
 RobustShotResult flight_time_robust_adjust(
     float turret_x, float turret_y, float turret_z,
@@ -206,7 +209,7 @@ RobustShotResult flight_time_robust_adjust(
     float target2_x, float target2_y, float target2_z,
     float robot_vx, float robot_vy,
     const TurretState& current,
-    float omega_drop,
+    float drop_fraction,
     const TurretWeights& weights,
     const TurretBounds&  bounds,
     const PhysicsConfig& cfg,
@@ -233,10 +236,10 @@ RobustShotResult flight_time_robust_adjust(
         return r;
     }
 
-    // --- Per-target Lipschitz constants (same compute_L as flight_time_robust) ---
-    auto compute_L = [&](float dx, float dy, float dz,
-                         float tx, float ty, float tz,
-                         float t_lo, float t_hi) -> float {
+    // --- Per-target Lipschitz constants ---
+    auto compute_L_raw = [&](float dx, float dy, float dz,
+                             float tx, float ty, float tz,
+                             float t_lo, float t_hi) -> std::pair<float, float> {
         LipschitzBounds lip = ballistics_lipschitz(dx, dy, dz, robot_vx, robot_vy,
                                                    t_lo, t_hi, cfg);
         float t_mid = 0.5f * (t_lo + t_hi);
@@ -250,16 +253,22 @@ RobustShotResult flight_time_robust_adjust(
         float v_hi   = s_mid.v_exit + lip.l_vexit * hw;
         float l_om = omega_map_lipschitz(omega, phi_lo, phi_hi, v_lo, v_hi,
                                          lip.l_phi, lip.l_vexit);
-        return std::max({weights.w_theta * lip.l_theta,
-                         weights.w_phi   * lip.l_phi,
-                         weights.w_omega * l_om});
+        float l_geom = std::max(weights.w_theta * lip.l_theta,
+                                weights.w_phi   * lip.l_phi);
+        return {l_geom, l_om};
     };
 
-    float L_T1 = compute_L(dx1, dy1, dz1, target1_x, target1_y, target1_z, iv1.t_lo, iv1.t_hi);
-    float L_T2 = compute_L(dx2, dy2, dz2, target2_x, target2_y, target2_z, iv2.t_lo, iv2.t_hi);
+    auto [l1_geom, l1_om] = compute_L_raw(dx1, dy1, dz1, target1_x, target1_y, target1_z, iv1.t_lo, iv1.t_hi);
+    auto [l2_geom, l2_om] = compute_L_raw(dx2, dy2, dz2, target2_x, target2_y, target2_z, iv2.t_lo, iv2.t_hi);
 
-    float L1 = 2.f * L_T1;   // A and B both contribute L_T1 in T1
-    float L2 = L_T2;         // only B contributes in T2
+    // Term A = J_Δ(cur, s1): L_A in T1 uses full omega Lipschitz (unscaled)
+    float L_A = std::max(l1_geom, weights.w_omega * l1_om);
+    // Term B = J_Δ(s1_reduced, s2): s1's omega is scaled by (1-drop_fraction)
+    float L_B_T1 = std::max(l1_geom, weights.w_omega * (1.f - drop_fraction) * l1_om);
+    float L_B_T2 = std::max(l2_geom, weights.w_omega * l2_om);
+
+    float L1 = L_A + L_B_T1;  // A and B both contribute in T1
+    float L2 = L_B_T2;        // only B contributes in T2
 
     // --- Objective: A + B ---
     auto J = [&](float t1, float t2) -> float {
@@ -274,7 +283,7 @@ RobustShotResult flight_time_robust_adjust(
         float A = flight_time_tau(s1, current, weights, omega);
 
         // B = J_Δ(s1_reduced → s2), no Δθ wrap (same-goal consecutive shots).
-        float b_om1 = s1.omega_flywheel - omega_drop;
+        float b_om1 = s1.omega_flywheel * (1.f - drop_fraction);
         float b_om2 = s2.omega_flywheel;
         float b_d_omega = std::abs(b_om1 - b_om2);
         float b_d_phi   = std::abs(s1.phi   - s2.phi);

--- a/deps/turret_planner/tests/test_ballistics.cpp
+++ b/deps/turret_planner/tests/test_ballistics.cpp
@@ -54,7 +54,8 @@ void test_dtheta_dT() {
     double T = 0.4, eps = 1e-7;
 
     // Analytic (float)
-    float analytic = ballistics_dtheta_dT(float(dx), float(dy), float(vRx), float(vRy), float(T));
+    PhysicsConfig cfg{9.81f, 0.1f};
+    float analytic = ballistics_dtheta_dT(float(dx), float(dy), float(vRx), float(vRy), float(T), cfg);
 
     // FD in double for accuracy
     auto eval_theta_d = [&](double t) {

--- a/deps/turret_planner/tests/test_preposition.cpp
+++ b/deps/turret_planner/tests/test_preposition.cpp
@@ -182,7 +182,7 @@ void test_robust_feasibility() {
         cur, 10.f, 0.f, K, weights, bounds, cfg, om_rich);
     PrepositionResult rob0 = preposition_robust_compute(
         path, K, 0,0,0, 0,0, 1.f,
-        cur, 10.f, 0.f, K, /*omega_drop=*/0.f, weights, bounds, cfg, om_rich);
+        cur, 10.f, 0.f, K, /*drop_fraction=*/0.f, weights, bounds, cfg, om_rich);
 
     printf("plain theta=%.4f phi=%.4f om=%.2f\n",
         plain.target.theta, plain.target.phi, plain.target.omega_flywheel);
@@ -201,7 +201,7 @@ void test_robust_feasibility() {
 }
 
 // -------------------------------------------------------------------------
-// test 6: a non-zero omega_drop should produce a different preposition
+// test 6: a non-zero drop_fraction should produce a different preposition
 // (sanity check that the drop parameter actually flows through).
 // -------------------------------------------------------------------------
 void test_robust_drop_shifts_target() {
@@ -223,11 +223,11 @@ void test_robust_drop_shifts_target() {
         cur, 10.f, 0.f, K, 0.f, weights, bounds, cfg, om_rich);
     PrepositionResult r1 = preposition_robust_compute(
         path, K, 0,0,0, 0,0, 1.f,
-        cur, 10.f, 0.f, K, 30.f, weights, bounds, cfg, om_rich);
+        cur, 10.f, 0.f, K, 0.15f, weights, bounds, cfg, om_rich);
 
-    printf("drop=0  theta=%.4f phi=%.4f om=%.2f\n",
+    printf("drop=0    theta=%.4f phi=%.4f om=%.2f\n",
         r0.target.theta, r0.target.phi, r0.target.omega_flywheel);
-    printf("drop=30 theta=%.4f phi=%.4f om=%.2f\n",
+    printf("drop=0.15 theta=%.4f phi=%.4f om=%.2f\n",
         r1.target.theta, r1.target.phi, r1.target.omega_flywheel);
 
     // Something (theta, phi, or omega) should differ meaningfully.
@@ -236,7 +236,7 @@ void test_robust_drop_shifts_target() {
     float d_om    = std::abs(r0.target.omega_flywheel - r1.target.omega_flywheel);
     printf("|dtheta|=%.4f  |dphi|=%.4f  |dom|=%.4f\n", d_theta, d_phi, d_om);
     assert(d_theta + d_phi + d_om > 1e-3f
-           && "non-zero omega_drop should change the preposition target");
+           && "non-zero drop_fraction should change the preposition target");
     printf("PASS robust_drop_shifts_target\n");
 }
 

--- a/deps/turret_planner/tests/test_robust_3shot.cpp
+++ b/deps/turret_planner/tests/test_robust_3shot.cpp
@@ -40,7 +40,7 @@ void test_static_1ball() {
     Robust3ShotResult r = robust_3shot_plan(
         traj, N, 0.f,
         3.f, 0.f, target_z,
-        cur, 1, 0.f, 0.2f, 0.005f, 3.f,
+        cur, 1, 0.f, 0.2f, 0.005f,
         weights, bounds, cfg, om);
 
     printf("feasible=%d  idx1=%d  T1=%.4f  J=%.6f\n",
@@ -66,7 +66,7 @@ void test_static_2ball() {
     Robust3ShotResult r = robust_3shot_plan(
         traj, N, 0.f,
         3.f, 0.f, target_z,
-        cur, 2, 0.f, 0.2f, 0.005f, 3.f,
+        cur, 2, 0.f, 0.2f, 0.005f,
         weights, bounds, cfg, om);
 
     printf("feasible=%d  idx1=%d  T1=%.4f T2=%.4f  J=%.6f\n",
@@ -92,7 +92,7 @@ void test_static_3ball() {
     Robust3ShotResult r = robust_3shot_plan(
         traj, N, 0.f,
         3.f, 0.f, target_z,
-        cur, 3, 0.f, 0.2f, 0.005f, 3.f,
+        cur, 3, 0.f, 0.2f, 0.005f,
         weights, bounds, cfg, om);
 
     printf("feasible=%d  T1=%.4f T2=%.4f T3=%.4f  J=%.6f\n",
@@ -123,7 +123,7 @@ void test_moving_trajectory() {
     Robust3ShotResult r = robust_3shot_plan(
         traj, N, 0.f,
         3.f, 0.f, target_z,
-        cur, 2, 0.f, 0.2f, 0.005f, 3.f,
+        cur, 2, 0.f, 0.2f, 0.005f,
         weights, bounds, cfg, om);
 
     printf("feasible=%d  idx1=%d  t1=%.3f  J=%.6f\n",
@@ -148,7 +148,7 @@ void test_transfer_timing() {
     Robust3ShotResult r = robust_3shot_plan(
         traj, N, 0.f,
         3.f, 0.f, 1.5f,
-        cur, 3, t_remaining, transfer_time, 0.005f, 3.f,
+        cur, 3, t_remaining, transfer_time, 0.005f,
         weights, bounds, cfg, om);
 
     if (r.feasible) {
@@ -160,12 +160,50 @@ void test_transfer_timing() {
     printf("PASS transfer_timing\n");
 }
 
+void test_no_backward_shot() {
+    printf("\n=== test_no_backward_shot ===\n");
+    // Robot is close to the target and moving toward it at high speed.
+    // Without the directional constraint, the solver could find a backwards-
+    // pointing solution where theta ≈ π (turret faces away from goal).
+    const int N = 40;
+    FutureState traj[N];
+    // Robot at (1, 0) moving at vx=2 m/s toward target at (3, 0).
+    // At T > 0.5s the velocity correction can flip theta.
+    make_trajectory(traj, N, 1.f, 0.f, 2.f, 0.f, 0.f, 0.05f);
+
+    TurretState cur{0.f, 0.3f, 900.f};
+    float target_z = 1.5f;
+
+    Robust3ShotResult r = robust_3shot_plan(
+        traj, N, 0.f,
+        3.f, 0.f, target_z,
+        cur, 1, 0.f, 0.2f, 0.005f,
+        weights, bounds, cfg, om);
+
+    printf("feasible=%d  idx1=%d  T1=%.4f  J=%.6f\n",
+           r.feasible, r.idx1, r.T1, r.J);
+    if (r.feasible) {
+        printf("  s1: theta=%.4f phi=%.4f vExit=%.3f\n",
+               r.s1.theta, r.s1.phi, r.s1.v_exit);
+        // Goal is in the +x direction (theta ≈ 0 from early trajectory points).
+        // The shot theta must not be backwards (|theta| must be < π/2).
+        float goal_angle = std::atan2(0.f - 0.f, 3.f - 1.f);  // atan2(0, 2) = 0
+        float d = std::abs(r.s1.theta - goal_angle);
+        if (d > 3.14159265f) d = 6.28318530f - d;
+        printf("  angle deviation from goal: %.4f rad (%.1f deg)\n",
+               d, d * 180.f / 3.14159265f);
+        assert(d < 1.5707963f && "shot must not point backwards from goal");
+    }
+    printf("PASS no_backward_shot\n");
+}
+
 int main() {
     test_static_1ball();
     test_static_2ball();
     test_static_3ball();
     test_moving_trajectory();
     test_transfer_timing();
+    test_no_backward_shot();
     printf("\nDone.\n");
     return 0;
 }

--- a/deps/turret_planner/tests/test_robust_3shot.cpp
+++ b/deps/turret_planner/tests/test_robust_3shot.cpp
@@ -1,0 +1,171 @@
+#include <cstdio>
+#include <cmath>
+#include <cassert>
+#include <algorithm>
+#include "turret_planner/robust_3shot.h"
+#include "turret_planner/ballistics.h"
+#include "turret_planner/flywheel_model.h"
+
+// Use a non-trivial omega map so the flywheel-drop arm actually matters:
+//   omega = 800 + 40*v + 50*phi
+static PhysicsConfig  cfg{9.81f, 0.1f, 0.f};
+static OmegaMapParams om{{800.f, 40.f, 50.f, 0.f, 0.f, 0.f}};
+static TurretBounds   bounds{-3.14f, 3.14f, 0.f, 1.4f, 15.f, 2000.f};
+static TurretWeights  weights{0.05f, 0.08f, 0.0005f};
+
+// Build a constant-velocity trajectory
+static void make_trajectory(FutureState* out, int n,
+                            float x0, float y0, float vx, float vy,
+                            float t_start, float dt) {
+    for (int i = 0; i < n; ++i) {
+        float t = t_start + i * dt;
+        out[i].t = t;
+        out[i].x = x0 + vx * t;
+        out[i].y = y0 + vy * t;
+        out[i].heading = 0.f;
+        out[i].vx = vx;
+        out[i].vy = vy;
+    }
+}
+
+void test_static_1ball() {
+    printf("\n=== test_static_1ball ===\n");
+    const int N = 20;
+    FutureState traj[N];
+    make_trajectory(traj, N, 0.f, 0.f, 0.f, 0.f, 0.f, 0.05f);
+
+    TurretState cur{0.f, 0.3f, 900.f};
+    float target_z = 1.5f;
+
+    Robust3ShotResult r = robust_3shot_plan(
+        traj, N, 0.f,
+        3.f, 0.f, target_z,
+        cur, 1, 0.f, 0.2f, 0.005f, 3.f,
+        weights, bounds, cfg, om);
+
+    printf("feasible=%d  idx1=%d  T1=%.4f  J=%.6f\n",
+           r.feasible, r.idx1, r.T1, r.J);
+    printf("  s1: theta=%.4f phi=%.4f vExit=%.3f\n",
+           r.s1.theta, r.s1.phi, r.s1.v_exit);
+
+    assert(r.feasible);
+    // With t_remaining=0, solver can pick any trajectory sample
+    assert(r.idx1 >= 0);
+    printf("PASS static_1ball\n");
+}
+
+void test_static_2ball() {
+    printf("\n=== test_static_2ball ===\n");
+    const int N = 30;
+    FutureState traj[N];
+    make_trajectory(traj, N, 0.f, 0.f, 0.f, 0.f, 0.f, 0.05f);
+
+    TurretState cur{0.f, 0.3f, 900.f};
+    float target_z = 1.5f;
+
+    Robust3ShotResult r = robust_3shot_plan(
+        traj, N, 0.f,
+        3.f, 0.f, target_z,
+        cur, 2, 0.f, 0.2f, 0.005f, 3.f,
+        weights, bounds, cfg, om);
+
+    printf("feasible=%d  idx1=%d  T1=%.4f T2=%.4f  J=%.6f\n",
+           r.feasible, r.idx1, r.T1, r.T2, r.J);
+    printf("  s1: theta=%.4f phi=%.4f vExit=%.3f omega=%.2f\n",
+           r.s1.theta, r.s1.phi, r.s1.v_exit, r.s1.omega_flywheel);
+    printf("  s2: theta=%.4f phi=%.4f vExit=%.3f omega=%.2f\n",
+           r.s2.theta, r.s2.phi, r.s2.v_exit, r.s2.omega_flywheel);
+
+    assert(r.feasible);
+    printf("PASS static_2ball\n");
+}
+
+void test_static_3ball() {
+    printf("\n=== test_static_3ball ===\n");
+    const int N = 40;
+    FutureState traj[N];
+    make_trajectory(traj, N, 0.f, 0.f, 0.f, 0.f, 0.f, 0.05f);
+
+    TurretState cur{0.f, 0.3f, 900.f};
+    float target_z = 1.5f;
+
+    Robust3ShotResult r = robust_3shot_plan(
+        traj, N, 0.f,
+        3.f, 0.f, target_z,
+        cur, 3, 0.f, 0.2f, 0.005f, 3.f,
+        weights, bounds, cfg, om);
+
+    printf("feasible=%d  T1=%.4f T2=%.4f T3=%.4f  J=%.6f\n",
+           r.feasible, r.T1, r.T2, r.T3, r.J);
+    printf("  s1: theta=%.4f phi=%.4f vExit=%.3f omega=%.2f\n",
+           r.s1.theta, r.s1.phi, r.s1.v_exit, r.s1.omega_flywheel);
+    printf("  s2: theta=%.4f phi=%.4f vExit=%.3f omega=%.2f\n",
+           r.s2.theta, r.s2.phi, r.s2.v_exit, r.s2.omega_flywheel);
+    printf("  s3: theta=%.4f phi=%.4f vExit=%.3f omega=%.2f\n",
+           r.s3.theta, r.s3.phi, r.s3.v_exit, r.s3.omega_flywheel);
+
+    assert(r.feasible);
+    printf("PASS static_3ball\n");
+}
+
+void test_moving_trajectory() {
+    printf("\n=== test_moving_trajectory ===\n");
+    // Robot starts 5m away and drives toward the target at 0.5 m/s.
+    // Shots should be delayed to get closer (better geometry).
+    const int N = 40;
+    FutureState traj[N];
+    // Moving in +x toward target at (3, 0)
+    make_trajectory(traj, N, -2.f, 0.f, 0.5f, 0.f, 0.f, 0.05f);
+
+    TurretState cur{0.f, 0.3f, 900.f};
+    float target_z = 1.5f;
+
+    Robust3ShotResult r = robust_3shot_plan(
+        traj, N, 0.f,
+        3.f, 0.f, target_z,
+        cur, 2, 0.f, 0.2f, 0.005f, 3.f,
+        weights, bounds, cfg, om);
+
+    printf("feasible=%d  idx1=%d  t1=%.3f  J=%.6f\n",
+           r.feasible, r.idx1, r.idx1 >= 0 ? traj[r.idx1].t : -1.f, r.J);
+
+    assert(r.feasible);
+    printf("PASS moving_trajectory\n");
+}
+
+void test_transfer_timing() {
+    printf("\n=== test_transfer_timing ===\n");
+    // Verify that shot timing respects t_remaining constraint.
+    // t_remaining = time until next ball can exit = 0.3s
+    const int N = 40;
+    FutureState traj[N];
+    make_trajectory(traj, N, 0.f, 0.f, 0.f, 0.f, 0.f, 0.05f);
+
+    TurretState cur{0.f, 0.3f, 900.f};
+    float transfer_time = 0.2f;
+    float t_remaining = 0.3f;  // next ball exits in 0.3s
+
+    Robust3ShotResult r = robust_3shot_plan(
+        traj, N, 0.f,
+        3.f, 0.f, 1.5f,
+        cur, 3, t_remaining, transfer_time, 0.005f, 3.f,
+        weights, bounds, cfg, om);
+
+    if (r.feasible) {
+        float t1 = traj[r.idx1].t;
+        printf("t_remaining=%.2f\n", t_remaining);
+        printf("shot1 at t=%.3f (min %.3f)\n", t1, t_remaining);
+        assert(t1 >= t_remaining - 1e-3f);
+    }
+    printf("PASS transfer_timing\n");
+}
+
+int main() {
+    test_static_1ball();
+    test_static_2ball();
+    test_static_3ball();
+    test_moving_trajectory();
+    test_transfer_timing();
+    printf("\nDone.\n");
+    return 0;
+}

--- a/deps/turret_planner/tests/test_robust_shot.cpp
+++ b/deps/turret_planner/tests/test_robust_shot.cpp
@@ -14,8 +14,8 @@ static TurretBounds   bounds{-3.14f, 3.14f, 0.f, 1.4f, 15.f, 2000.f};
 static TurretWeights  weights{0.05f, 0.08f, 0.0005f};
 
 static float robust_move_cost(const ShotParams& s1, const ShotParams& s2,
-                              float omega_drop) {
-    float om1 = omega_map_eval(om, s1.phi, s1.v_exit) - omega_drop;
+                              float drop_fraction) {
+    float om1 = omega_map_eval(om, s1.phi, s1.v_exit) * (1.f - drop_fraction);
     float om2 = omega_map_eval(om, s2.phi, s2.v_exit);
     float d_omega = std::abs(om1 - om2);
     float d_phi   = std::abs(s1.phi   - s2.phi);
@@ -27,7 +27,7 @@ static float robust_move_cost(const ShotParams& s1, const ShotParams& s2,
 
 void test_robust_matches_grid() {
     printf("\n=== test_robust_matches_grid ===\n");
-    const float omega_drop = 5.f;
+    const float drop_fraction = 0.005f;  // ~0.5% proportional drop
 
     // Two distinct targets (different xyz → different theta, phi).
     float t1x = 3.0f, t1y = 0.0f, t1z = 1.5f;
@@ -53,7 +53,7 @@ void test_robust_matches_grid() {
             float T2 = iv2.t_lo + (iv2.t_hi - iv2.t_lo) * float(j) / float(N);
             ShotParams s2 = ballistics_solve(0,0,0, t2x, t2y, t2z, 0, 0, T2, cfg, om);
             if (!ballistics_is_feasible(s2, T2, bounds, cfg)) continue;
-            float cost = robust_move_cost(s1, s2, omega_drop);
+            float cost = robust_move_cost(s1, s2, drop_fraction);
             if (cost < best_grid_cost) {
                 best_grid_cost = cost;
                 best_T1 = T1;
@@ -68,7 +68,7 @@ void test_robust_matches_grid() {
     // Solver.
     RobustShotResult r = flight_time_robust(
         0,0,0, t1x, t1y, t1z, t2x, t2y, t2z,
-        0, 0, omega_drop, weights, bounds, cfg, om,
+        0, 0, drop_fraction, weights, bounds, cfg, om,
         /*tol=*/0.01f, /*maxIter=*/200);
 
     printf("solver: feasible=%d  T1=%.4f  T2=%.4f  J=%.6f\n",
@@ -80,7 +80,7 @@ void test_robust_matches_grid() {
     assert(r.feasible);
 
     // Recompute cost from the solver output (J should match robust_move_cost).
-    float solver_cost = robust_move_cost(r.s1, r.s2, omega_drop);
+    float solver_cost = robust_move_cost(r.s1, r.s2, drop_fraction);
     printf("solver cost (recomputed): %.6f   solver J: %.6f\n", solver_cost, r.J);
     assert(std::abs(solver_cost - r.J) < 1e-4f);
 
@@ -105,7 +105,7 @@ void test_infeasible_interval() {
 
 // Helper: reference objective for flight_time_robust_adjust.
 static float adjust_cost(const ShotParams& s1, const ShotParams& s2,
-                         const TurretState& cur, float omega_drop) {
+                         const TurretState& cur, float drop_fraction) {
     // A = J_Δ(cur, s1) with Δθ wrap.
     float a_d_theta = std::abs(s1.theta - cur.theta);
     if (a_d_theta > 3.14159265f) a_d_theta = 6.28318530f - a_d_theta;
@@ -115,7 +115,7 @@ static float adjust_cost(const ShotParams& s1, const ShotParams& s2,
                         weights.w_phi   * a_d_phi,
                         weights.w_omega * a_d_omega});
     // B = J_Δ(s1_reduced, s2)
-    float b_om1 = s1.omega_flywheel - omega_drop;
+    float b_om1 = s1.omega_flywheel * (1.f - drop_fraction);
     float b_d_omega = std::abs(b_om1 - s2.omega_flywheel);
     float b_d_phi   = std::abs(s1.phi   - s2.phi);
     float b_d_theta = std::abs(s1.theta - s2.theta);
@@ -127,7 +127,7 @@ static float adjust_cost(const ShotParams& s1, const ShotParams& s2,
 
 void test_adjust_matches_grid() {
     printf("\n=== test_adjust_matches_grid ===\n");
-    const float omega_drop = 5.f;
+    const float drop_fraction = 0.005f;  // ~0.5% proportional drop
     // Current turret state deliberately offset from any optimal shot so the
     // A term (cur → s1 slew) is non-trivial.
     TurretState cur{-0.3f, 0.4f, 900.f};
@@ -151,7 +151,7 @@ void test_adjust_matches_grid() {
             float T2 = iv2.t_lo + (iv2.t_hi - iv2.t_lo) * float(j) / float(N);
             ShotParams s2 = ballistics_solve(0,0,0, t2x, t2y, t2z, 0, 0, T2, cfg, om);
             if (!ballistics_is_feasible(s2, T2, bounds, cfg)) continue;
-            float cost = adjust_cost(s1, s2, cur, omega_drop);
+            float cost = adjust_cost(s1, s2, cur, drop_fraction);
             if (cost < best_grid_cost) {
                 best_grid_cost = cost;
                 best_T1 = T1;
@@ -164,14 +164,14 @@ void test_adjust_matches_grid() {
 
     RobustShotResult r = flight_time_robust_adjust(
         0,0,0, t1x, t1y, t1z, t2x, t2y, t2z,
-        0, 0, cur, omega_drop, weights, bounds, cfg, om,
+        0, 0, cur, drop_fraction, weights, bounds, cfg, om,
         /*tol=*/0.01f, /*maxIter=*/200);
 
     printf("solver: feasible=%d  T1=%.4f  T2=%.4f  J=%.6f\n",
            r.feasible, r.T1, r.T2, r.J);
     assert(r.feasible);
 
-    float solver_cost = adjust_cost(r.s1, r.s2, cur, omega_drop);
+    float solver_cost = adjust_cost(r.s1, r.s2, cur, drop_fraction);
     printf("solver cost (recomputed): %.6f   solver J: %.6f\n", solver_cost, r.J);
     assert(std::abs(solver_cost - r.J) < 1e-4f);
 
@@ -184,7 +184,7 @@ void test_adjust_matches_grid() {
 
 void test_adjust_same_target_drop_zero() {
     printf("\n=== test_adjust_same_target_drop_zero ===\n");
-    // With omega_drop=0 and target1==target2, the B term is minimized at T1=T2
+    // With drop_fraction=0 and target1==target2, the B term is minimized at T1=T2
     // and the objective degenerates to A = J_Δ(cur → s1). The solver should
     // pick (T1, T2) with T1 ≈ T2 and a small J.
     TurretState cur{0.1f, 0.5f, 700.f};
@@ -192,7 +192,7 @@ void test_adjust_same_target_drop_zero() {
 
     RobustShotResult r = flight_time_robust_adjust(
         0,0,0, tx, ty, tz, tx, ty, tz,
-        0, 0, cur, /*omega_drop=*/0.f, weights, bounds, cfg, om,
+        0, 0, cur, /*drop_fraction=*/0.f, weights, bounds, cfg, om,
         /*tol=*/0.005f, /*maxIter=*/100);
 
     printf("feasible=%d  T1=%.4f  T2=%.4f  J=%.6f\n", r.feasible, r.T1, r.T2, r.J);


### PR DESCRIPTION
## Summary

Reworks the MainTeleOp gamepad control scheme for competition:

- **GP2 drive toggle (X):** GP2 can now take over mecanum drive controls. When enabled, GP2 sticks drive the robot and GP2 triggers map to intake/shoot. When disabled (default), GP2 right stick X controls the turret manually and triggers do nothing.
- **Flywheel always-on toggle (GP2 right bumper):** Flywheel idles at 0.4 power by default (starts ON). Toggle off with right bumper to fully stop the flywheel when idle.
- **Flywheel spin-up (GP2 left bumper only):** Removed flywheel spin-up from GP1 left bumper. Now GP2-only.
- **Robot-centric default:** TeleOp now starts in robot-centric mode instead of field-centric. GP1 X still toggles between the two.
- **GP2 left trigger remapped:** Acts as intake when GP2 drive is active (previously was reverse intake). Reverse intake is now B on either gamepad.
- **Telemetry:** Added flywheel always-on and GP2 drive status indicators.

## Test plan

- [ ] Verify GP1 drive, intake (left trigger), reverse (B), and shoot (right trigger) work as before
- [ ] Verify GP1 left bumper no longer spins up flywheel
- [ ] Verify teleop starts in robot-centric mode
- [ ] Toggle GP2 drive with X — confirm GP2 sticks drive the robot and GP2 triggers intake/shoot
- [ ] Toggle GP2 drive off — confirm GP2 right stick X controls turret, triggers do nothing
- [ ] Verify flywheel idles at 0.4 power on startup
- [ ] Toggle flywheel always-on off with GP2 right bumper — confirm flywheel stops when idle
- [ ] Verify GP2 left bumper spins up flywheel without shooting

🤖 Generated with [Claude Code](https://claude.com/claude-code)